### PR TITLE
Resolve issue: UI tests can not run

### DIFF
--- a/Test/Chronozoom.Test/CzCommon.cs
+++ b/Test/Chronozoom.Test/CzCommon.cs
@@ -8,8 +8,8 @@ namespace Chronozoom.Test
         public static readonly Uri StartPage = new Uri("http://www.bing.com/");
         public static readonly BrowserType BrowserName = BrowserType.Firefox;
 
-        public const string ChromeDriverDirectory = "../../../../External/WebDrivers/";
-        public const string IeDriverDirectory = "../../../../External/WebDrivers/";
+        public const string ChromeDriverDirectory = "../../../External/WebDrivers/";
+        public const string IeDriverDirectory = "../../../External/WebDrivers/";
 
         public const string StartPagePrefix = "http://localhost:4949/";
         public const string RCDefaultAddress = "http://localhost:4444/wb/hub/";


### PR DESCRIPTION
Earlier all binaries copy to /bin/DevPreview or /bin/Debug, now
regardless of configuration all binaries copy to /bin/. This commit
should fix UI tests running.
