### PR TITLE
Bug22: Can't retrieve data from CZ

### DIFF
--- a/Source/Chronozoom.Entities/Exhibit.cs
+++ b/Source/Chronozoom.Entities/Exhibit.cs
@@ -50,5 +50,11 @@ namespace Chronozoom.Entities
 
         [DataMember]
         public virtual Collection<Reference> References { get; private set; }
+
+        public Exhibit()
+        {
+            ContentItems = new Collection<ContentItem>();
+            References = new Collection<Reference>();
+        }
     }
 }

--- a/Source/Chronozoom.Entities/Timeline.cs
+++ b/Source/Chronozoom.Entities/Timeline.cs
@@ -60,10 +60,18 @@ namespace Chronozoom.Entities
         [DataMember]
         public decimal? Height { get; set; }
 
+        public virtual Timeline ParentTimeline { get; private set; }
+
         [DataMember]
         public virtual Collection<Timeline> ChildTimelines { get; private set; }
 
         [DataMember]
         public virtual Collection<Exhibit> Exhibits { get; private set; }
+
+        public Timeline()
+        {
+            ChildTimelines = new Collection<Timeline>();
+            Exhibits = new Collection<Exhibit>();
+        }
     }
 }

--- a/Source/Chronozoom.UI/Chronozoom.svc.cs
+++ b/Source/Chronozoom.UI/Chronozoom.svc.cs
@@ -41,7 +41,8 @@ namespace UI
                 if (!Cache.Contains("Timelines"))
                 {
                     Trace.TraceInformation("Get Timelines Cache Miss");
-                    var t = _storage.Timelines.Find(new Guid("468A8005-36E3-4676-9F52-312D8B6EB7B7")); // Hardcoded 'root' timeline :-(
+
+                    var t = _storage.RootTimeline();
                     LoadChildren(t);
 
                     Cache.Add("Timelines", new [] { t }, DateTime.Now.AddMinutes(int.Parse(ConfigurationManager.AppSettings["CacheDuration"], CultureInfo.InvariantCulture)));

--- a/Source/Chronozoom.UI/Global.asax.cs
+++ b/Source/Chronozoom.UI/Global.asax.cs
@@ -26,6 +26,9 @@ namespace UI
 
             RouteTable.Routes.MapHubs();
 
+            // If required, upgrades the storage.
+            Storage.Upgrade();
+
             Trace.TraceInformation("Application Starting");
         }
 

--- a/Source/Chronozoom.UI/Web.config
+++ b/Source/Chronozoom.UI/Web.config
@@ -10,6 +10,9 @@
   </configSections>
   <connectionStrings>
     <add name="Storage" connectionString="Data Source=|DataDirectory|Storage.sdf" providerName="System.Data.SqlServerCe.4.0" />
+    
+    <!-- Uncomment to use SQL Server -->
+    <!-- <add name="Storage" connectionString="Data Source=localhost;Initial Catalog=CZLocal;Integrated Security=True;" providerName="System.Data.SqlClient" /> -->
   </connectionStrings>
   <appSettings>
     <add key="CacheDuration" value="5" />

--- a/Source/DataMigration/App.config
+++ b/Source/DataMigration/App.config
@@ -6,6 +6,9 @@
   </configSections>
   <connectionStrings>
     <add name="Storage" connectionString="Data Source=|DataDirectory|Storage.sdf" providerName="System.Data.SqlServerCe.4.0" />
+
+    <!-- Uncomment to use SQL Azure -->
+    <!-- <add name="Storage" connectionString="Data Source=server.database.windows.net;Initial Catalog=database;user id=user@server;password=password" providerName="System.Data.SqlClient" /> -->
   </connectionStrings>
   <startup>
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />


### PR DESCRIPTION
1. Current code assumed a given GUID as the timeline head. Changed to use first timeline with no parent.
2. This fix required to add the "ParentTimeline" property to the Timeline entity, which modified the name of a SQL field. This caused deployment to fail in databases already deployed since a upgrade behavior was not defined. Therefore, entity upgrade behavior was also added with this change. The current behavior allows dropping data (if required) to perform a schema upgrade.
3. Added commented connection strings to enable data migration to work with SQL Azure and local deployments to use SQL Server.

This fix has already been verified and closed by a-chumagin, see: https://github.com/alterm4nn/ChronoZoom/issues/22
