### PR TITLE
Bug22: Can't retrieve data from CZ

### DIFF
--- a/Source/Chronozoom.Entities/Storage.cs
+++ b/Source/Chronozoom.Entities/Storage.cs
@@ -50,7 +50,7 @@ namespace Chronozoom.Entities
                 }
 
                 Trace.TraceInformation("Seeding database with data");
-                context.Timelines.Add(new Timeline { ID = Guid.NewGuid(), UniqueID = 655, Title = "Hello world", FromYear = 711, ToYear = 1492, Height = 20, FromTimeUnit = "CE", ToTimeUnit = "CE" });
+                context.Timelines.Add(new Timeline { ID = Guid.Empty, UniqueID = 655, Title = "Hello world", FromYear = 711, ToYear = 1492, Height = 20, FromTimeUnit = "CE", ToTimeUnit = "CE" });
             } 
         }
     }

--- a/Source/Chronozoom.UI/Chronozoom.svc.cs
+++ b/Source/Chronozoom.UI/Chronozoom.svc.cs
@@ -41,7 +41,7 @@ namespace UI
                 if (!Cache.Contains("Timelines"))
                 {
                     Trace.TraceInformation("Get Timelines Cache Miss");
-                    var t = _storage.Timelines.Find(new Guid("468A8005-36E3-4676-9F52-312D8B6EB7B7")); // Hardcoded 'root' timeline :-(
+                    var t = _storage.Timelines.Find(Guid.Empty);
                     LoadChildren(t);
 
                     Cache.Add("Timelines", new [] { t }, DateTime.Now.AddMinutes(int.Parse(ConfigurationManager.AppSettings["CacheDuration"], CultureInfo.InvariantCulture)));


### PR DESCRIPTION
Scoped down previous Bug22 pull request. This change contains a simple fix to mark the root timeline as the Guid.Empty to allow developers and deployments to retrieve Chronozoom data.
