### PR TITLE
Bug45: Search engine results for ChronoZoom have no description

### DIFF
--- a/Source/Chronozoom.UI/robots.txt
+++ b/Source/Chronozoom.UI/robots.txt
@@ -1,3 +1,3 @@
-﻿# robots.txt generated at http://www.mcanerin.com
-User-agent: *
+﻿User-agent: *
 Disallow: /
+Allow: /*.htm$


### PR DESCRIPTION
Search results in Bing and Google for ChronoZoom return:
- Bing: Empty
- Google: A description for this result is not available because of this site's robots.txt 

Currently, robots.txt is blocking everything. Therefore, crawlers can't retrieve the description as specified in the meta tag.

This change allows all root .htm (but not specific timelines, exhibits, etc.) to be indexed by crawlers.
