### PR TITLE
Bug30: Loading data from SQL into the CZ website takes too long

### DIFF
--- a/Source/Chronozoom.Entities/ContentItem.cs
+++ b/Source/Chronozoom.Entities/ContentItem.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Serialization;
 
@@ -58,5 +59,12 @@ namespace Chronozoom.Entities
 
         [DataMember]
         public bool HasBibliography { get; set; }
+    }
+
+    [DataContract]
+    [NotMapped]
+    public class ContentItemRaw : ContentItem
+    {
+        public Guid Exhibit_ID { get; set; }
     }
 }

--- a/Source/Chronozoom.Entities/Entities.cd
+++ b/Source/Chronozoom.Entities/Entities.cd
@@ -13,16 +13,9 @@
     </Members>
     <AssociationLine Name="ContentItems" Type="Chronozoom.Entities.ContentItem" FixedFromPoint="true" FixedToPoint="true">
       <Path>
-        <Point X="6.625" Y="5.988" />
+        <Point X="6.625" Y="6.18" />
         <Point X="6.625" Y="7.032" />
         <Point X="7.25" Y="7.032" />
-      </Path>
-    </AssociationLine>
-    <AssociationLine Name="References" Type="Chronozoom.Entities.Reference" FixedFromPoint="true" FixedToPoint="true">
-      <Path>
-        <Point X="5.938" Y="5.988" />
-        <Point X="5.938" Y="8.802" />
-        <Point X="7.25" Y="8.802" />
       </Path>
     </AssociationLine>
     <TypeIdentifier>
@@ -31,7 +24,6 @@
     </TypeIdentifier>
     <ShowAsCollectionAssociation>
       <Property Name="ContentItems" />
-      <Property Name="References" />
     </ShowAsCollectionAssociation>
   </Class>
   <Class Name="Chronozoom.Entities.Timeline">
@@ -61,8 +53,8 @@
       <Path>
         <Point X="4.75" Y="3.754" />
         <Point X="5.125" Y="3.754" />
-        <Point X="5.125" Y="5.31" />
-        <Point X="5.5" Y="5.31" />
+        <Point X="5.125" Y="5.415" />
+        <Point X="5.5" Y="5.415" />
       </Path>
     </AssociationLine>
     <TypeIdentifier>
@@ -125,14 +117,14 @@
   <Class Name="Chronozoom.Entities.Collection">
     <Position X="0.75" Y="0.75" Width="1.5" />
     <TypeIdentifier>
-      <HashCode>AAACAAAAAAAAAEAAAAAAAggAAAAAAAAAAAAAAAAAAAA=</HashCode>
+      <HashCode>AAACAAAAAAAAAEAAAAAAAAgAAAAAAAAAAAAAAAAAAAA=</HashCode>
       <FileName>Collection.cs</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Chronozoom.Entities.SuperCollection">
     <Position X="3.25" Y="0.75" Width="1.5" />
     <TypeIdentifier>
-      <HashCode>AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=</HashCode>
+      <HashCode>AAACAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAIAAAAA=</HashCode>
       <FileName>SuperCollection.cs</FileName>
     </TypeIdentifier>
   </Class>

--- a/Source/Chronozoom.Entities/Exhibit.cs
+++ b/Source/Chronozoom.Entities/Exhibit.cs
@@ -7,10 +7,13 @@
 using System;
 using System.Collections.ObjectModel;
 using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 using System.Runtime.Serialization;
 
 namespace Chronozoom.Entities
 {
+    [KnownType(typeof(ContentItemRaw))]
+    [KnownType(typeof(ReferenceRaw))]
     [DataContract]
     public class Exhibit
     {
@@ -46,9 +49,16 @@ namespace Chronozoom.Entities
         public int? Sequence { get; set; }
 
         [DataMember]
-        public virtual Collection<ContentItem> ContentItems { get; private set; }
+        public virtual Collection<ContentItem> ContentItems { get; set; }
 
         [DataMember]
-        public virtual Collection<Reference> References { get; private set; }
+        public virtual Collection<Reference> References { get; set; }
+    }
+
+    [DataContract]
+    [NotMapped]
+    public class ExhibitRaw : Exhibit
+    {
+        public Guid Timeline_ID { get; set; }
     }
 }

--- a/Source/Chronozoom.Entities/Reference.cs
+++ b/Source/Chronozoom.Entities/Reference.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 using System.Runtime.Serialization;
 
 namespace Chronozoom.Entities
@@ -40,5 +41,12 @@ namespace Chronozoom.Entities
 
         [DataMember]
         public string Source { get; set; }
+    }
+
+    [DataContract]
+    [NotMapped]
+    public class ReferenceRaw : Reference
+    {
+        public Guid Exhibit_ID { get; set; }
     }
 }

--- a/Source/Chronozoom.Entities/Storage.cs
+++ b/Source/Chronozoom.Entities/Storage.cs
@@ -5,11 +5,19 @@
 // --------------------------------------------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Data.Common;
 using System.Data.Entity;
+using System.Data.Entity.Infrastructure;
 using System.Data.Entity.Migrations;
 using System.Data.Entity.Migrations.Design;
+using System.Data.SqlClient;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
+using System.Reflection;
+using System.Runtime.Serialization;
 
 namespace Chronozoom.Entities
 {
@@ -47,5 +55,82 @@ namespace Chronozoom.Entities
 
         public DbSet<SuperCollection> SuperCollections { get; set; }
 
+        public List<Timeline> TimelinesQuery()
+        {
+            Dictionary<Guid, Timeline> timelinesMap = new Dictionary<Guid, Timeline>();
+            List<Timeline> timelines = FillTimelines(timelinesMap);
+
+            FillTimelineRelations(timelinesMap);
+
+            return timelines;
+        }
+
+        private void FillTimelineRelations(Dictionary<Guid, Timeline> timelinesMap)
+        {
+            // Populate Exhibits
+            string exhibitsQuery = "SELECT * FROM Exhibits";
+            var exhibitsRaw = Database.SqlQuery<ExhibitRaw>(exhibitsQuery);
+            Dictionary<Guid, Exhibit> exhibits = new Dictionary<Guid, Exhibit>();
+            foreach (ExhibitRaw exhibitRaw in exhibitsRaw)
+            {
+                if (exhibitRaw.ContentItems == null)
+                    exhibitRaw.ContentItems = new System.Collections.ObjectModel.Collection<ContentItem>();
+
+                if (exhibitRaw.References == null)
+                    exhibitRaw.References = new System.Collections.ObjectModel.Collection<Reference>();
+
+                timelinesMap[exhibitRaw.Timeline_ID].Exhibits.Add(exhibitRaw);
+                exhibits[exhibitRaw.ID] = exhibitRaw;
+            }
+
+            // Populate Content Items
+            string contentItemsQuery = "SELECT * FROM ContentItems";
+            var contentItemsRaw = Database.SqlQuery<ContentItemRaw>(contentItemsQuery);
+            foreach (ContentItemRaw contentItemRaw in contentItemsRaw)
+                exhibits[contentItemRaw.Exhibit_ID].ContentItems.Add(contentItemRaw);
+
+            // Populate References
+            string referencesQuery = "SELECT * FROM [References]";
+            var referencesRaw = Database.SqlQuery<ReferenceRaw>(referencesQuery);
+            foreach (ReferenceRaw referenceRaw in referencesRaw)
+                exhibits[referenceRaw.Exhibit_ID].References.Add(referenceRaw);
+        }
+
+        private List<Timeline> FillTimelines(Dictionary<Guid, Timeline> timelinesMap)
+        {
+            List<Timeline> timelines = new List<Timeline>();
+            Dictionary<Guid, Guid?> timelinesParents = new Dictionary<Guid, Guid?>();
+
+            // Populate References
+            string timelinesQuery = "SELECT * FROM Timelines";
+            var timelinesRaw = Database.SqlQuery<TimelineRaw>(timelinesQuery);
+            foreach (TimelineRaw timelineRaw in timelinesRaw)
+            {
+                if (timelineRaw.ChildTimelines == null)
+                    timelineRaw.ChildTimelines = new System.Collections.ObjectModel.Collection<Timeline>();
+
+                if (timelineRaw.Exhibits == null)
+                    timelineRaw.Exhibits = new System.Collections.ObjectModel.Collection<Exhibit>();
+
+                timelinesParents[timelineRaw.ID] = timelineRaw.Timeline_ID;
+                timelinesMap[timelineRaw.ID] = timelineRaw;
+            }
+
+            // Build the timelines tree by assigning each timeline to its parent
+            foreach (Timeline timeline in timelinesMap.Values)
+            {
+                Guid? parentId = timelinesParents[timeline.ID];
+                if (parentId != null)
+                {
+                    timelinesMap[(Guid)parentId].ChildTimelines.Add(timeline);
+                }
+                else
+                {
+                    timelines.Add(timeline);
+                }
+            }
+
+            return timelines;
+        }
     }
 }

--- a/Source/Chronozoom.Entities/Threshold.cs
+++ b/Source/Chronozoom.Entities/Threshold.cs
@@ -8,6 +8,7 @@ using System.Runtime.Serialization;
 
 namespace Chronozoom.Entities
 {
+    [KnownType(typeof(ExhibitRaw))]
     [DataContract]
     public class Threshold
     {

--- a/Source/Chronozoom.Entities/Timeline.cs
+++ b/Source/Chronozoom.Entities/Timeline.cs
@@ -7,10 +7,13 @@
 using System;
 using System.Collections.ObjectModel;
 using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 using System.Runtime.Serialization;
 
 namespace Chronozoom.Entities
 {
+    [KnownType(typeof(TimelineRaw))]
+    [KnownType(typeof(ExhibitRaw))]
     [DataContract]
     public class Timeline
     {
@@ -61,12 +64,19 @@ namespace Chronozoom.Entities
         public decimal? Height { get; set; }
 
         [DataMember]
-        public virtual Collection<Timeline> ChildTimelines { get; private set; }
+        public virtual Collection<Timeline> ChildTimelines { get; set; }
 
         [DataMember]
-        public virtual Collection<Exhibit> Exhibits { get; private set; }
+        public virtual Collection<Exhibit> Exhibits { get; set; }
 
         [DataMember]
         public virtual Entities.Collection Collection { get; set; }
+    }
+
+    [DataContract]
+    [NotMapped]
+    public class TimelineRaw : Timeline
+    {
+        public Guid? Timeline_ID { get; set; }
     }
 }

--- a/Source/Chronozoom.UI/Chronozoom.svc.cs
+++ b/Source/Chronozoom.UI/Chronozoom.svc.cs
@@ -41,31 +41,12 @@ namespace UI
                 if (!Cache.Contains("Timelines"))
                 {
                     Trace.TraceInformation("Get Timelines Cache Miss");
-                    var t = _storage.Timelines.Find(Guid.Empty);
-                    LoadChildren(t);
 
-                    Cache.Add("Timelines", new [] { t }, DateTime.Now.AddMinutes(int.Parse(ConfigurationManager.AppSettings["CacheDuration"], CultureInfo.InvariantCulture)));
+                    Timeline t = _storage.TimelinesQuery().Find(timeline => timeline.ID == Guid.Empty);
+                    Cache.Add("Timelines", new[] { t }, DateTime.Now.AddMinutes(int.Parse(ConfigurationManager.AppSettings["CacheDuration"], CultureInfo.InvariantCulture)));
                 }
 
                 return (IEnumerable<Timeline>)Cache["Timelines"];
-            }
-        }
-
-        private void LoadChildren(Timeline t)
-        {
-            _storage.Entry(t).Collection(_ => _.Exhibits).Load();
-
-            foreach (var e in t.Exhibits)
-            {
-                _storage.Entry(e).Collection(_ => _.ContentItems).Load();
-                _storage.Entry(e).Collection(_ => _.References).Load();
-            }
-
-            _storage.Entry(t).Collection(_ => _.ChildTimelines).Load();
-
-            foreach (var c in t.ChildTimelines)
-            {
-                LoadChildren(c);
             }
         }
 
@@ -136,8 +117,9 @@ namespace UI
             return exhibit.References.ToList();
         }
 
-        [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate", Justification = "Not appropriate")][
-        OperationContract]
+        [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate", Justification = "Not appropriate")]
+        [
+            OperationContract]
         [WebGet(ResponseFormat = WebMessageFormat.Json)]
         public IEnumerable<Tour> GetTours()
         {


### PR DESCRIPTION
Scenario: When ChronoZoom timeline cache refreshes (every 5 minutes), users experience a 30 seconds delay to load timeline data.

Defect: Loading data through the entity framework using Load() causes entity framework to generate one SQL query per entity, for all ChronoZoom data this triggered hundred of SQL calls. The measurement I got was 29.1268517 seconds required to load timeline data on cache-miss scenarios (ran in local environment)

Solution: Instead of loading data by loading entity properties, this change performs one query per entity to retrieve all elements. This reduces, the load process to 4 SQL queries (which should still be optimized and run in parallel but that's something to address in a subsequent improvement.) With this change, loading all ChronoZoom data into the cache averaged 0.5410725 seconds (ran in local environment).
