### PR TITLE
Bug65: Tours missing. Bookmarks property in tours JSON response changed and broke compatibility with client.

### DIFF
--- a/Source/Chronozoom.Entities/Tour.cs
+++ b/Source/Chronozoom.Entities/Tour.cs
@@ -34,7 +34,7 @@ namespace Chronozoom.Entities
         [DataMember]
         public int? Sequence { get; set; }
 
-        [DataMember]
+        [DataMember(Name="bookmarks")]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification="Automatically implemented properties must define both get and set accessors.")]
         public virtual Collection<Bookmark> Bookmarks { get; private set; }
     }


### PR DESCRIPTION
Tours missing are missing in latest build. Tracked by #65.

Defect: Bookmarks property in tours JSON response changed and broke compatibility with client.

Fix: Preserve Bookmarks property casing.
