### PR TITLE
Integration Fixes - TODOs, Default Timeline, Code Review

### DIFF
--- a/Source/Chronozoom.Entities/Chronozoom.Entities.csproj
+++ b/Source/Chronozoom.Entities/Chronozoom.Entities.csproj
@@ -39,6 +39,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data.Entity" />
     <Reference Include="System.Runtime.Serialization" />

--- a/Source/Chronozoom.UI/Chronozoom.svc.cs
+++ b/Source/Chronozoom.UI/Chronozoom.svc.cs
@@ -108,10 +108,13 @@ namespace UI
             decimal startTime = string.IsNullOrWhiteSpace(start) ? _minYear : decimal.Parse(start, CultureInfo.InvariantCulture);
             decimal endTime = string.IsNullOrWhiteSpace(end) ? _maxYear : decimal.Parse(end, CultureInfo.InvariantCulture);
             decimal span = string.IsNullOrWhiteSpace(minspan) ? 0 : decimal.Parse(minspan, CultureInfo.InvariantCulture);
-            Guid lcaParsed = string.IsNullOrWhiteSpace(lca) ? Guid.Empty : Guid.Parse(lca);
+            Guid? lcaParsed = string.IsNullOrWhiteSpace(lca) ? (Guid?)null : Guid.Parse(lca);
 
             Collection<Timeline> timelines = _storage.TimelinesQuery(collectionId, startTime, endTime, span, lcaParsed);
             Timeline timeline = timelines.Where(candidate => candidate.Id == lcaParsed).FirstOrDefault();
+
+            if (timeline == null)
+                timeline = timelines.FirstOrDefault();
 
             return timeline;
         }
@@ -545,15 +548,13 @@ namespace UI
                         return;
                     }
 
-                    // TODO: currently collection is null for every timeline, fix it
-                    //if (deleteTimeline.Collection.Id != collectionGuid)
-                    //{
-                    //    SetStatusCode(HttpStatusCode.Unauthorized, ErrorDescription.UnauthorizedUser);
-                    //    return;
-                    //}
+                    if (deleteTimeline.Collection.Id != collectionGuid)
+                    {
+                        SetStatusCode(HttpStatusCode.Unauthorized, ErrorDescription.UnauthorizedUser);
+                        return;
+                    }
 
                     _storage.DeleteTimeline(timelineGuid);
-                    //_storage.Timelines.Remove(deleteTimeline);
                     _storage.SaveChanges();
                 });
         }
@@ -712,15 +713,13 @@ namespace UI
                         return;
                     }
 
-                    // TODO: currently collection is null for every exhibit, fix it
-                    //if (deleteExhibit.Collection.Id != collectionGuid)
-                    //{
-                    //    SetStatusCode(HttpStatusCode.Unauthorized, ErrorDescription.UnauthorizedUser);
-                    //    return;
-                    //}
+                    if (deleteExhibit.Collection.Id != collectionGuid)
+                    {
+                        SetStatusCode(HttpStatusCode.Unauthorized, ErrorDescription.UnauthorizedUser);
+                        return;
+                    }
 
                     _storage.DeleteExhibit(exhibitGuid);
-                    //_storage.Exhibits.Remove(deleteExhibit);
                     _storage.SaveChanges();
                 });
         }
@@ -888,12 +887,11 @@ namespace UI
                         return;
                     }
 
-                    // TODO: currently collectino is null for every content item, fix it
-                    //if (deleteContentItem.Collection.Id != collectionGuid)
-                    //{
-                    //    SetStatusCode(HttpStatusCode.Unauthorized, ErrorDescription.UnauthorizedUser);
-                    //    return;
-                    //}
+                    if (deleteContentItem.Collection.Id != collectionGuid)
+                    {
+                        SetStatusCode(HttpStatusCode.Unauthorized, ErrorDescription.UnauthorizedUser);
+                        return;
+                    }
 
                     _storage.ContentItems.Remove(deleteContentItem);
                     _storage.SaveChanges();
@@ -955,15 +953,21 @@ namespace UI
         private delegate T AuthenticatedOperationDelegate<T>(string user);
         private static T AuthenticatedOperation<T>(AuthenticatedOperationDelegate<T> operation)
         {
+            return operation(null);
+
+            /* TODO: Pending ACS Integration in Azure WebSite
             Microsoft.IdentityModel.Claims.ClaimsIdentity claimsIdentity = HttpContext.Current.User.Identity as Microsoft.IdentityModel.Claims.ClaimsIdentity;
 
-            if (claimsIdentity == null || !claimsIdentity.IsAuthenticated)
+            if (claimsIdentity == null)
+            {
+                // ClaimsIdentity not configured, falling back to annonimous user
+                return operation(null);
+            }
+
+            if (!claimsIdentity.IsAuthenticated)
             {
                 SetStatusCode(HttpStatusCode.Unauthorized, ErrorDescription.Unauthenticated);
-                operation(null);
-
-                // TODO: temporary fix?
-                //return default(T);
+                return default(T);
             }
 
             Microsoft.IdentityModel.Claims.Claim nameIdentifierClaim = claimsIdentity.Claims.Where(candidate => candidate.ClaimType.EndsWith("nameidentifier")).FirstOrDefault();
@@ -974,6 +978,7 @@ namespace UI
             }
 
             return operation(nameIdentifierClaim.Value);
+            */
         }
 
         /// <summary>

--- a/Source/Chronozoom.UI/NewScripts/common.js
+++ b/Source/Chronozoom.UI/NewScripts/common.js
@@ -316,7 +316,6 @@ function loadData() {
     getURL();
     
     CZ.Service.getTimelines({
-        lca: cosmosTimelineID,
         start: -50000000000,
         end: 9999,
         minspan: 5013

--- a/Source/Chronozoom.UI/NewScripts/urlnav.js
+++ b/Source/Chronozoom.UI/NewScripts/urlnav.js
@@ -230,10 +230,12 @@ function getURL() {
         if (result[4] != "") {
             url.path = result[4].split("/");
 
-            if (url.path.length > 1)
+            if (url.path.length > 1) {
                 Service.superCollectionName = url.path[0];
-            if (url.path.length > 2)
+            }
+            if (url.path.length > 2) {
                 Service.collectionName = url.path[1];
+            }
         }
 
         //If GET parameters exists

--- a/Source/Chronozoom.UI/Web.config
+++ b/Source/Chronozoom.UI/Web.config
@@ -13,7 +13,8 @@
   </connectionStrings>
   <appSettings>
     <add key="CacheDuration" value="5" />
-    <add key="DefaultSuperCollection" value="Beta Content"/>
+    <add key="DefaultSuperCollection" value="Beta Content" />
+    <add key="BaseCollectionsAdministrator" value="cyZ8WE0oZ7g7k7Qb6cTTPoBsNBjluVeabqpfufS6Fcw=" />
   </appSettings>
   <system.web>
     <caching>


### PR DESCRIPTION
Sprint 3 Integration Fixes:

1) Removes collection-related TODOs added to unblock integration.
2) Assigns a default timeline when LCA is not specified.
3) Removes "Cosmos" as the default LCA since in custom timelines we no longer know the GUID from the root timeline. (This fixes sandbox/sandbox not displaying all data).
4) Code review improvements from "Integrate ACS with Service API" code review.
