### PR TITLE
RI-Tree Cleanup, Fixes and UseRiTreeQuery Setting

### DIFF
--- a/Source/Chronozoom.Entities/Bitmask.cs
+++ b/Source/Chronozoom.Entities/Bitmask.cs
@@ -10,13 +10,13 @@ namespace Chronozoom.Entities
     {
         [Key]
         [DataMember]
-        public long b1 { get; set; }
+        public long B1 { get; set; }
 
         [DataMember]
-        public long b2 { get; set; }
+        public long B2 { get; set; }
 
         [DataMember]
-        public long b3 { get; set; }
+        public long B3 { get; set; }
 
     }
 

--- a/Source/Chronozoom.Entities/Migration/Migrator.cs
+++ b/Source/Chronozoom.Entities/Migration/Migrator.cs
@@ -46,38 +46,36 @@ namespace Chronozoom.Entities.Migration
 
         public void Migrate()
         {
-            /* insert bitmask constants */
-            _storage.Bitmasks.SqlQuery("delete from Bitmasks");
-            long v = 1;
-            foreach (var b in _storage.Bitmasks)
-            {
-                _storage.Bitmasks.Remove(b);
-            }
-            _storage.SaveChanges();
-            for (int r = 0; r < 34; ++r)
-            {
-                Bitmask b = new Bitmask();
-                b.b1 = -v * 2;
-                b.b2 = v;
-                b.b3 = v * 2;
-                _storage.Bitmasks.Add(b);
-                v *= 2;
-            }
-            _storage.SaveChanges();
-            
-            /*
-                // those indexes already exist in current DB, so not creating them again
-
-                CREATE NONCLUSTERED INDEX [start_time_idx] ON [timeline]([node], [start_time]);
-                CREATE NONCLUSTERED INDEX [end_time_idx] ON [timeline]([node], [end_time]);
-             
-             */
+            MigrateRiTree();
 
             LoadDataFromDump("Beta Content", "beta-get.json", "beta-gettours.json", "beta-getthresholds.json", false, _baseContentAdmin.Value);
             LoadDataFromDump("Sandbox", "beta-get.json", "beta-gettours.json", "beta-getthresholds.json", true, null);
             LoadDataFromDump("AIDS Timeline", "aidstimeline-get.json", "aidstimeline-gettours.json", null, true, _baseContentAdmin.Value);
             LoadDataFromDump("AIDS Standalone", "aidsstandalone-get.json", null, null, true, _baseContentAdmin.Value);
             LoadDataFromDump("CERN", "cern-get.json", null, null, true, null);
+        }
+
+        private void MigrateRiTree()
+        {
+            if (!_storage.Bitmasks.Any())
+            {
+                long v = 1;
+                foreach (var b in _storage.Bitmasks)
+                {
+                    _storage.Bitmasks.Remove(b);
+                }
+                _storage.SaveChanges();
+                for (int r = 0; r < 34; ++r)
+                {
+                    Bitmask b = new Bitmask();
+                    b.B1 = -v * 2;
+                    b.B2 = v;
+                    b.B3 = v * 2;
+                    _storage.Bitmasks.Add(b);
+                    v *= 2;
+                }
+                _storage.SaveChanges();
+            }
         }
 
         private void LoadDataFromDump(string superCollectionName, string getFileName, string getToursFileName, string getThresholdsFileName, bool replaceGuids, string contentAdminId)

--- a/Source/Chronozoom.UI/Chronozoom.UI.csproj
+++ b/Source/Chronozoom.UI/Chronozoom.UI.csproj
@@ -170,9 +170,6 @@
     </Content>
     <Content Include="NewScripts\cz.settings.ts" />
     <TypeScriptCompile Include="NewScripts\cz.ts" />
-    <Content Include="NewScripts\czservice.min.js">
-      <DependentUpon>czservice.ts</DependentUpon>
-    </Content>
     <Content Include="NewScripts\czservice.ts" />
     <Content Include="NewScripts\external\flash_detect.js" />
     <Content Include="NewScripts\external\jquery-1.7.2.min.js" />
@@ -186,9 +183,6 @@
     <Content Include="NewScripts\external\seadragon-min.js" />
     <Content Include="NewScripts\gestures.ts" />
     <Content Include="NewScripts\layout.ts" />
-    <Content Include="NewScripts\regimesIE.min.js">
-      <DependentUpon>regimesIE.ts</DependentUpon>
-    </Content>
     <Content Include="NewScripts\regimesIE.ts" />
     <Content Include="NewScripts\search.ts" />
     <Content Include="NewScripts\timescale.ts" />

--- a/Source/Chronozoom.UI/Chronozoom.svc.cs
+++ b/Source/Chronozoom.UI/Chronozoom.svc.cs
@@ -342,7 +342,9 @@ namespace UI
         /// authenticated user is set as the author if no author is already registered.
         ///
         /// If the collection exists and the authenticated user is its author then
-        /// the title of the existing collection is modified.
+        /// the collection is modified.
+        /// 
+        /// The title field can't be modified since it's part of the URL and the URL is indexable by 3rd parties.
         /// </summary>
         [OperationContract]
         [WebInvoke(Method = "PUT", UriTemplate = "/{superCollectionName}/{collectionName}", RequestFormat = WebMessageFormat.Json, ResponseFormat = WebMessageFormat.Json)]
@@ -376,7 +378,7 @@ namespace UI
                             return retval;
                         }
 
-                        collection.Title = collectionRequest.Title;
+                        // Modify collection fields. However, title can't be modified since it would change the URL and break indexing.
                     }
                     _storage.SaveChanges();
                     return retval;

--- a/Source/Chronozoom.UI/cz2.html
+++ b/Source/Chronozoom.UI/cz2.html
@@ -56,7 +56,7 @@
     <script type="text/javascript" src="/NewScripts/regimesIE.js"></script>
     <![endif]-->
 
-    <script type="text/javascript" src="NewScripts/cz.js"></script>
+    <script type="text/javascript" src="/NewScripts/cz.js"></script>
     <title>ChronoZoom</title>
 </head>
 <body style="background-color: Black; min-width: 950px;">


### PR DESCRIPTION
1) Build got broken as a merge check-in conflict between turning on Code Analysis and warnings from RI-Tree check-in.
2) Adding UseRiTreeQUery setting to enable performance measurements in the same server by changing settings from Azure management.
3) Disabling RI-Tree since it throws a "The data types decimal and bigint are incompatible" exception.
4) Encapsulating RI-Tree migration logic and triggering only when bitmasks table is empty.
