### PR TITLE
Add Windows Identity Foundation Installation Step

### DIFF
--- a/Doc/ChronoZoom_Developer_Guide.md
+++ b/Doc/ChronoZoom_Developer_Guide.md
@@ -34,6 +34,7 @@ If you are new to GitHub, we recommend reading [Learning to use GitHub for Chron
 - [Visual Studio Tools for Git](http://visualstudiogallery.msdn.microsoft.com/abafc7d6-dcaa-40f4-8a5e-d6724bdb980c)
 - [Git for Windows](http://code.google.com/p/msysgit/downloads/list?q=full+installer+official+git)
  - Be sure to select 'Run Git from the Windows Command Prompt' during installation.
+- Install Windows Identity Foundation (Control Panel, Programs and Features, Turn Windows Feature on or off, Turn on Windows Identity Foundation 3.5)
 - [Stylecop](http://stylecop.codeplex.com/)
 
 ### Recommended ###

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Installation
 
 * Make a fork of https://github.com/alterm4nn/ChronoZoom
 * git clone git://github.com/<your-username>/ChronoZoom.git (Case Sensitive)
+* Install Windows Identity Foundation (Control Panel, Programs and Features, Turn Windows Feature on or off, Turn on Windows Identity Foundation 3.5)
 * Launch source\chronozoom.sln
 * Enable EnableNuGetPackageRestore (Right click on VS Solution - Enable NuGet Package Restore)
 * Use [F5] to compile and run ChronoZoom locally


### PR DESCRIPTION
During Sprint-3 a dependency to ACS was introduced to the ChronoZoom server. This change adds the additional installation steps.

Code Review (approved): http://mrccodereview.cloudapp.net/ui#review:id=1097
