### PR TITLE
Fix #19 Avoid using Eval() in ChronoZoom

### DIFF
--- a/Source/Chronozoom.UI/NewScripts/bibliography.js
+++ b/Source/Chronozoom.UI/NewScripts/bibliography.js
@@ -203,11 +203,7 @@ var CZ;
                 },
                 url: url,
                 success: function (result) {
-                    if(CZ.Settings.czDataSource == 'db') {
-                        onBiblReceived(result.d);
-                    } else {
-                        onBiblReceived(eval(result.d));
-                    }
+                    onBiblReceived(result.d);
                 },
                 error: function (xhr) {
                     console.log("Error connecting to service: " + xhr.responseText);

--- a/Source/Chronozoom.UI/NewScripts/bibliography.ts
+++ b/Source/Chronozoom.UI/NewScripts/bibliography.ts
@@ -205,10 +205,7 @@ module CZ {
                 data: { exhibitID: exhibitID },
                 url: url,
                 success: function (result) {
-                    if (CZ.Settings.czDataSource == 'db')
-                        onBiblReceived(result.d);
-                    else
-                        onBiblReceived(eval(result.d));
+                    onBiblReceived(result.d);
                 },
                 error: function (xhr) {
                     console.log("Error connecting to service: " + xhr.responseText);

--- a/Source/Chronozoom.UI/NewScripts/search.js
+++ b/Source/Chronozoom.UI/NewScripts/search.js
@@ -229,11 +229,7 @@ var CZ;
                 },
                 url: url,
                 success: function (result) {
-                    if(CZ.Settings.czDataSource == 'db') {
-                        onSearchResults(searchString, result.d);
-                    } else {
-                        onSearchResults(searchString, eval(result.d));
-                    }
+                    onSearchResults(searchString, result.d);
                 },
                 error: function (xhr) {
                     console.log("Error connecting to service: " + xhr.responseText);

--- a/Source/Chronozoom.UI/NewScripts/search.ts
+++ b/Source/Chronozoom.UI/NewScripts/search.ts
@@ -238,10 +238,7 @@ module CZ {
                 data: { searchTerm: searchString, supercollection: CZ.Service.superCollectionName, collection: CZ.Service.collectionName },
                 url: url,
                 success: function (result) {
-                    if (CZ.Settings.czDataSource == 'db')
-                        onSearchResults(searchString, result.d);
-                    else
-                        onSearchResults(searchString, eval(result.d));
+                    onSearchResults(searchString, result.d);
                 },
                 error: function (xhr) {
                     console.log("Error connecting to service: " + xhr.responseText);


### PR DESCRIPTION
Remove code paths using eval() from ChronoZoom. Fixes: https://github.com/alterm4nn/ChronoZoom/issues/19

Code Review: http://mrccodereview.cloudapp.net/ui#review:id=1132
  MSU Approved (Client Only Change)
