### PR TITLE
Improve Timelines Query Performance

### DIFF
--- a/Source/Chronozoom.Entities/Storage.cs
+++ b/Source/Chronozoom.Entities/Storage.cs
@@ -180,7 +180,17 @@ namespace Chronozoom.Entities
                     TOP({0}) *,
                     FromYear as [Start],
                     ToYear as [End]
-                FROM Timelines
+                FROM Timelines,
+                    (
+                        SELECT TOP(1) Id as AncestorId
+                        FROM Timelines 
+                        WHERE 
+                            (Timeline_Id Is NULL OR Id = {5})
+                            AND Collection_Id = {4}
+                        ORDER BY 
+                            CASE WHEN Id = {5} THEN 1 ELSE 0 END DESC, 
+                            CASE WHEN Id Is NULL THEN 1 ELSE 0 END DESC
+                    ) as AncestorTimeline
                 WHERE
                     Collection_Id = {4} AND
                     (
@@ -190,20 +200,8 @@ namespace Chronozoom.Entities
                         Id = {5}
                     )
                  ORDER BY
-                    CASE WHEN Id = {5} THEN 1 ELSE 0 END DESC, 
-                    CASE WHEN Timeline_Id = {5} THEN 1 ELSE 0 END DESC, 
-                    CASE WHEN Id = 
-                    (SELECT id 
-                        FROM Timelines 
-                        WHERE Timeline_Id Is NULL 
-                        AND Collection_Id = {4}
-                    ) THEN 1 ELSE 0 END DESC, 
-                    CASE WHEN Timeline_Id = 
-                    (SELECT id 
-                        FROM Timelines 
-                        WHERE Timeline_Id Is NULL 
-                        AND Collection_Id = {4}
-                    ) THEN 1 ELSE 0 END DESC,
+                    CASE WHEN Timelines.Id = AncestorId THEN 1 ELSE 0 END DESC, 
+                    CASE WHEN Timeline_Id = AncestorId THEN 1 ELSE 0 END DESC, 
                     ToYear-FromYear DESC";
 
             return FillTimelinesFromFlatList(


### PR DESCRIPTION
Improve Timelines TSQL Query Performance. Query plan shows that calculating ancestor timeline in ORDER BY clause causes SQL to create a comple temporary tables; instead, precalculate ancestor timeline calculation.

Code Review: http://mrccodereview.cloudapp.net/ui#review:id=1150
