### PR TITLE
Added Support for Thumbnail Generation

### DIFF
--- a/Source/Chronozoom.UI/Chronozoom.UI.csproj
+++ b/Source/Chronozoom.UI/Chronozoom.UI.csproj
@@ -77,6 +77,7 @@
       <Private>True</Private>
       <HintPath>..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.WindowsAzure.Storage, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
     <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Newtonsoft.Json.4.5.11\lib\net40\Newtonsoft.Json.dll</HintPath>
@@ -150,6 +151,7 @@
     <Content Include="ACS\FederationMetadata\2007-06\FederationMetadata.xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="utils\ThumbnailGenerator.cs" />
     <Content Include="BehindTheScenes.htm" />
     <Content Include="cz.aspx" />
     <Content Include="cz2.html" />

--- a/Source/Chronozoom.UI/Chronozoom.svc.cs
+++ b/Source/Chronozoom.UI/Chronozoom.svc.cs
@@ -5,29 +5,25 @@
 // --------------------------------------------------------------------------------------------------------------------
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Configuration;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
-using System.IO;
 using System.Linq;
 using System.Net;
-using System.Net.Http;
 using System.Runtime.Caching;
 using System.Runtime.Serialization;
-using System.Runtime.Serialization.Json;
 using System.Security.Cryptography;
 using System.ServiceModel;
 using System.ServiceModel.Activation;
 using System.ServiceModel.Web;
 using System.Text;
 using System.Web;
-using System.Web.Script.Services;
 using Chronozoom.Entities;
-using Newtonsoft.Json;
+
+using UI.Utils;
 
 namespace UI
 {
@@ -56,6 +52,31 @@ namespace UI
             return string.IsNullOrEmpty(maxElements) ? 2000 : int.Parse(maxElements);
         });
 
+        // Points to the absolute path where thumbnails are stored
+        private static Lazy<Uri> _thumbnailsPath = new Lazy<Uri>(() =>
+        {
+            if (ConfigurationManager.AppSettings["ThumbnailsPath"] == null)
+                return null;
+
+            return new Uri(ConfigurationManager.AppSettings["ThumbnailsPath"]);
+        });
+
+        private static Lazy<ThumbnailGenerator> _thumbnailGenerator = new Lazy<ThumbnailGenerator>(() =>
+        {
+            string thumbnailStorage = null;
+            if (ConfigurationManager.AppSettings["ThumbnailStorage"] != null)
+            {
+                thumbnailStorage = ConfigurationManager.AppSettings["ThumbnailStorage"];
+            }
+
+            return new ThumbnailGenerator(thumbnailStorage);
+        });
+
+        // The connection string to thumbnails storage
+        private static Lazy<string> _thumbnailsStorage = new Lazy<string>(() =>
+        {
+            return ConfigurationManager.AppSettings["ThumbnailStorage"];
+        });
 
         // error code descriptions
         private static class ErrorDescription
@@ -392,6 +413,35 @@ namespace UI
                 uriRequest = System.ServiceModel.OperationContext.Current.RequestContext.RequestMessage.Headers.To;
                 return new Uri(new Uri(uriRequest.GetLeftPart(UriPartial.Authority)), collectionUri.ToString()).ToString();
             });
+        }
+
+        /// <summary>
+        /// Provides a structure to retrieve information about this service.
+        /// </summary>
+        [DataContract]
+        public class ServiceInformation
+        {
+            /// <summary>
+            /// The path to download thumbanils from.
+            /// </summary>
+            [DataMember]
+            public Uri ThumbnailsPath { get; set; }
+        }
+
+        /// <summary>
+        /// Provides information about the ChronoZoom service to the clients. Used internally by the ChronoZoom client.
+        /// </summary>
+        /// <returns>A ServiceInformation object describing parameter from the running service</returns>
+        [OperationContract]
+        [WebInvoke(Method = "GET", UriTemplate = "/info", RequestFormat = WebMessageFormat.Json, ResponseFormat = WebMessageFormat.Json)]
+        public ServiceInformation GetServiceInformation()
+        {
+            Trace.TraceInformation("Get Service Information");
+
+            ServiceInformation serviceInformation = new ServiceInformation();
+            serviceInformation.ThumbnailsPath = _thumbnailsPath.Value;
+
+            return serviceInformation;
         }
 
         /// <summary>
@@ -1053,6 +1103,15 @@ namespace UI
                     }
                 }
                 _storage.SaveChanges();
+
+                if (exhibitRequest.ContentItems != null)
+                {
+                    foreach (ContentItem contentItem in exhibitRequest.ContentItems)
+                    {
+                        _thumbnailGenerator.Value.CreateThumbnails(contentItem);
+                    }
+                }
+
                 return returnValue;
             });
         }
@@ -1245,7 +1304,10 @@ namespace UI
                     Guid updateContentItemGuid = UpdateContentItem(collectionGuid, contentItemRequest);
                     returnValue = updateContentItemGuid;
                 }
+                
                 _storage.SaveChanges();
+                _thumbnailGenerator.Value.CreateThumbnails(contentItemRequest);
+
                 return returnValue;
             });
         }

--- a/Source/Chronozoom.UI/NewScripts/cz.js
+++ b/Source/Chronozoom.UI/NewScripts/cz.js
@@ -62,6 +62,9 @@ var CZ;
             CZ.Common.initialize();
             CZ.UILoader.loadAll(_uiMap).done(function () {
             });
+            CZ.Service.getServiceInformation().then(function (response) {
+                CZ.Settings.contentItemThumbnailBaseUri = response.ThumbnailsPath;
+            });
             var url = CZ.UrlNav.getURL();
             var rootCollection = url.superCollectionName === undefined;
             CZ.Service.superCollectionName = url.superCollectionName;

--- a/Source/Chronozoom.UI/NewScripts/cz.settings.js
+++ b/Source/Chronozoom.UI/NewScripts/cz.settings.js
@@ -153,7 +153,7 @@ var CZ;
             }
         ];
         Settings.seadragonServiceURL = "http://api.zoom.it/v1/content/?url=";
-        Settings.seadragonImagePath = "../Images/";
+        Settings.seadragonImagePath = "/Images/";
         Settings.seadragonMaxConnectionAttempts = 3;
         Settings.seadragonRetryInterval = 2000;
         Settings.navigateNextMaxCount = 2;

--- a/Source/Chronozoom.UI/NewScripts/cz.settings.ts
+++ b/Source/Chronozoom.UI/NewScripts/cz.settings.ts
@@ -138,7 +138,7 @@
 
         // seadragon
         export var seadragonServiceURL = "http://api.zoom.it/v1/content/?url=";
-        export var seadragonImagePath = "../Images/";
+        export var seadragonImagePath = "/Images/";
         export var seadragonMaxConnectionAttempts = 3;
         export var seadragonRetryInterval = 2000; // ms
 

--- a/Source/Chronozoom.UI/NewScripts/cz.ts
+++ b/Source/Chronozoom.UI/NewScripts/cz.ts
@@ -80,6 +80,11 @@ module CZ {
                 // TODO: Get UI components.
             });
 
+            CZ.Service.getServiceInformation().then(
+                function (response) {
+                    CZ.Settings.contentItemThumbnailBaseUri = response.ThumbnailsPath;
+                });
+
             var url = CZ.UrlNav.getURL();
             var rootCollection = url.superCollectionName === undefined;
             CZ.Service.superCollectionName = url.superCollectionName;

--- a/Source/Chronozoom.UI/NewScripts/czservice.js
+++ b/Source/Chronozoom.UI/NewScripts/czservice.js
@@ -262,6 +262,17 @@ var CZ;
             });
         }
         Service.getTours = getTours;
+        function getServiceInformation() {
+            var request = new Request(_serviceUrl);
+            request.addToPath("info");
+            return $.ajax({
+                type: "GET",
+                cache: false,
+                dataType: "json",
+                url: request.url
+            });
+        }
+        Service.getServiceInformation = getServiceInformation;
         function putExhibitContent(e, oldContentItems) {
             var newGuids = e.contentItems.map(function (ci) {
                 return ci.guid;

--- a/Source/Chronozoom.UI/NewScripts/czservice.ts
+++ b/Source/Chronozoom.UI/NewScripts/czservice.ts
@@ -320,6 +320,19 @@ module CZ {
             });
         }
 
+        // .../{supercollection}/{collection}/structure?start=&end=&minspan=&lca=
+        export function getServiceInformation() {
+            var request = new Request(_serviceUrl);
+            request.addToPath("info");
+
+            return $.ajax({
+                type: "GET",
+                cache: false,
+                dataType: "json",
+                url: request.url
+            });
+        }
+
         /**
         * Auxiliary Methods.
         */

--- a/Source/Chronozoom.UI/Web.config
+++ b/Source/Chronozoom.UI/Web.config
@@ -20,6 +20,8 @@
     <add key="UnobtrusiveJavaScriptEnabled" value="true" />
     <add key="FederationMetadataLocation" value="https://cz-nodelete-chronozoom-test.accesscontrol.windows.net/FederationMetadata/2007-06/FederationMetadata.xml" />
     <add key="MaxElementsDefault" value="2000" />
+    <!--<add key="ThumbnailStorage" value="DefaultEndpointsProtocol=https;AccountName=[];AccountKey=[]" />-->
+    <add key="ThumbnailsPath" value="http://cznodeletechronozoomtest.blob.core.windows.net/images/" />
   </appSettings>
   <system.web>
     <caching>

--- a/Source/Chronozoom.UI/utils/ThumbnailGenerator.cs
+++ b/Source/Chronozoom.UI/utils/ThumbnailGenerator.cs
@@ -1,0 +1,110 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Web;
+
+using Microsoft.WindowsAzure.Storage;
+using Microsoft.WindowsAzure.Storage.Blob;
+
+using Chronozoom.Entities;
+
+namespace UI.Utils
+{
+    /// <summary>
+    /// Helper class to generate content item thumbnails.
+    /// </summary>
+    public class ThumbnailGenerator
+    {
+        private string _thumbnailsStorage;
+
+        // The max size allowed to be processed for thumbnail source.
+        private const int _maxSourceContentLength = 10000000;
+
+        /// <summary>
+        /// Constructs a ThumbnailGenerator class
+        /// </summary>
+        /// <param name="thumbnailsStorage"></param>
+        public ThumbnailGenerator(string thumbnailsStorage)
+        {
+            _thumbnailsStorage = thumbnailsStorage;
+        }
+
+        /// <summary>
+        /// Creates and uploades to storage thumbnails for the given content item.
+        /// </summary>
+        /// <param name="contentItem"></param>
+        public void CreateThumbnails(ContentItem contentItem)
+        {
+            if (_thumbnailsStorage == null || contentItem.Uri == null || string.Compare(contentItem.MediaType, "Image", true, CultureInfo.InvariantCulture) != 0)
+                return;
+
+            // Retrieve storage account information
+            CloudStorageAccount storageAccount = CloudStorageAccount.Parse(_thumbnailsStorage);
+
+            // Create the blob client.
+            CloudBlobClient blobClient = storageAccount.CreateCloudBlobClient();
+
+            // Retrieve a reference to images container. 
+            CloudBlobContainer imagesContainer = blobClient.GetContainerReference("images");
+            if (!imagesContainer.Exists())
+            {
+                imagesContainer.CreateIfNotExists();
+                imagesContainer.SetPermissions(
+                    new BlobContainerPermissions
+                    {
+                        PublicAccess = BlobContainerPublicAccessType.Blob
+                    });
+            }
+
+            // Generate thumbnails
+            WebRequest request = WebRequest.Create(contentItem.Uri);
+            using (WebResponse response = request.GetResponse())
+            {
+                using (Stream responseStream = response.GetResponseStream())
+                {
+                    using (Bitmap bitmap = new Bitmap(responseStream))
+                    {
+                        if (response.ContentLength > _maxSourceContentLength)
+                        {
+                            throw new InvalidDataException("Source image is too big.");
+                        }
+
+                        SaveUploadThumbnail(imagesContainer, contentItem.Id.ToString(), bitmap, 8);
+                        SaveUploadThumbnail(imagesContainer, contentItem.Id.ToString(), bitmap, 16);
+                        SaveUploadThumbnail(imagesContainer, contentItem.Id.ToString(), bitmap, 32);
+                        SaveUploadThumbnail(imagesContainer, contentItem.Id.ToString(), bitmap, 64);
+                        SaveUploadThumbnail(imagesContainer, contentItem.Id.ToString(), bitmap, 128);
+                    }
+                }
+            }
+        }
+
+        private void SaveUploadThumbnail(CloudBlobContainer imagesContainer, string filename, Bitmap bitmap, int dimension)
+        {
+            if (imagesContainer == null)
+                return;
+
+            Bitmap thumbnail = new Bitmap(dimension, dimension);
+
+            Graphics graphics = Graphics.FromImage(thumbnail);
+            graphics.InterpolationMode = InterpolationMode.High;
+            graphics.DrawImage(bitmap, 0, 0, dimension, dimension);
+
+            using (MemoryStream thumbnailStream = new MemoryStream())
+            {
+                thumbnail.Save(thumbnailStream, System.Drawing.Imaging.ImageFormat.Png);
+
+                // Upload thumbnail
+                CloudBlockBlob blockBlob = imagesContainer.GetBlockBlobReference(@"x" + dimension + @"\" + filename + ".png");
+
+                thumbnailStream.Seek(0, SeekOrigin.Begin);
+                blockBlob.UploadFromStream(thumbnailStream);
+            }
+        }
+    }
+}

--- a/Source/Chronozoom.UI/utils/ThumbnailGenerator.cs.orig
+++ b/Source/Chronozoom.UI/utils/ThumbnailGenerator.cs.orig
@@ -1,0 +1,99 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Web;
+
+using Microsoft.WindowsAzure.Storage;
+using Microsoft.WindowsAzure.Storage.Blob;
+
+using Chronozoom.Entities;
+
+namespace UI.Utils
+{
+    public class ThumbnailGenerator
+    {
+        private string _thumbnailsStorage;
+
+        // The max size allowed to be processed for thumbnail source.
+        private const int _maxSourceContentLength = 10000000;
+
+        public ThumbnailGenerator(string thumbnailsStorage)
+        {
+            _thumbnailsStorage = thumbnailsStorage;
+        }
+
+        public void CreateThumbnails(ContentItem contentItem)
+        {
+            if (_thumbnailsStorage == null || contentItem.Uri == null || string.Compare(contentItem.MediaType, "Image", true, CultureInfo.InvariantCulture) != 0)
+                return;
+
+            // Retrieve storage account information
+            CloudStorageAccount storageAccount = CloudStorageAccount.Parse(_thumbnailsStorage);
+
+            // Create the blob client.
+            CloudBlobClient blobClient = storageAccount.CreateCloudBlobClient();
+
+            // Retrieve a reference to images container. 
+            CloudBlobContainer imagesContainer = blobClient.GetContainerReference("images");
+            if (!imagesContainer.Exists())
+            {
+                imagesContainer.CreateIfNotExists();
+                imagesContainer.SetPermissions(
+                    new BlobContainerPermissions
+                    {
+                        PublicAccess = BlobContainerPublicAccessType.Blob
+                    });
+            }
+
+            // Generate thumbnails
+            WebRequest request = WebRequest.Create(contentItem.Uri);
+            using (WebResponse response = request.GetResponse())
+            {
+                using (Stream responseStream = response.GetResponseStream())
+                {
+                    using (Bitmap bitmap = new Bitmap(responseStream))
+                    {
+                        if (response.ContentLength > _maxSourceContentLength)
+                        {
+                            throw new InvalidDataException("Source image is too big.");
+                        }
+
+                        SaveUploadThumbnail(imagesContainer, contentItem.Id.ToString(), bitmap, 8);
+                        SaveUploadThumbnail(imagesContainer, contentItem.Id.ToString(), bitmap, 16);
+                        SaveUploadThumbnail(imagesContainer, contentItem.Id.ToString(), bitmap, 32);
+                        SaveUploadThumbnail(imagesContainer, contentItem.Id.ToString(), bitmap, 64);
+                        SaveUploadThumbnail(imagesContainer, contentItem.Id.ToString(), bitmap, 128);
+                    }
+                }
+            }
+        }
+
+        private void SaveUploadThumbnail(CloudBlobContainer imagesContainer, string filename, Bitmap bitmap, int dimension)
+        {
+            if (imagesContainer == null)
+                return;
+
+            Bitmap thumbnail = new Bitmap(dimension, dimension);
+
+            Graphics graphics = Graphics.FromImage(thumbnail);
+            graphics.InterpolationMode = InterpolationMode.High;
+            graphics.DrawImage(bitmap, 0, 0, dimension, dimension);
+
+            using (MemoryStream thumbnailStream = new MemoryStream())
+            {
+                thumbnail.Save(thumbnailStream, System.Drawing.Imaging.ImageFormat.Png);
+
+                // Upload thumbnail
+                CloudBlockBlob blockBlob = imagesContainer.GetBlockBlobReference(@"x" + dimension + @"\" + filename + ".png");
+
+                thumbnailStream.Seek(0, SeekOrigin.Begin);
+                blockBlob.UploadFromStream(thumbnailStream);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Code Review Progress: http://mrccodereview.cloudapp.net/ui#review:id=1152

Added support for thumbnail generation when a content items gets saved. To support this scenario correctly, added:
- Added http://server/chronozoom.svc/info endpoint to retrieve the thumbnails path. This endpoint can be extended with additional server information as needed.
- Added web.config setting to configure connection to thumbnail storage
- Added web.config setting to point to the thumbnails server.

Misc: Fixed SeaDragon broken icons while browsing within a collection.
