### PR TITLE
HotFix: Fix Azure Blob Assembly Reference

### DIFF
--- a/Source/Chronozoom.UI/Chronozoom.UI.csproj
+++ b/Source/Chronozoom.UI/Chronozoom.UI.csproj
@@ -66,6 +66,14 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Microsoft.AspNet.SignalR.SystemWeb.1.0.0-rc2\lib\net45\Microsoft.AspNet.SignalR.SystemWeb.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Data.Edm, Version=5.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.Data.Edm.5.2.0\lib\net40\Microsoft.Data.Edm.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Data.OData, Version=5.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.Data.OData.5.2.0\lib\net40\Microsoft.Data.OData.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.IdentityModel, Version=3.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\External\IdentityModel\Microsoft.IdentityModel.dll</HintPath>
@@ -77,7 +85,9 @@
       <Private>True</Private>
       <HintPath>..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.Storage, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
+    <Reference Include="Microsoft.WindowsAzure.Storage, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\WindowsAzure.Storage.2.0.5.1\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Newtonsoft.Json.4.5.11\lib\net40\Newtonsoft.Json.dll</HintPath>
@@ -90,6 +100,7 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
     <Reference Include="System.Data.Entity" />
+    <Reference Include="System.Data.Services.Client" />
     <Reference Include="System.IdentityModel" />
     <Reference Include="System.identitymodel.services" />
     <Reference Include="System.Net.Http" />
@@ -105,6 +116,10 @@
     </Reference>
     <Reference Include="System.ServiceModel.Web">
       <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Spatial, Version=5.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\System.Spatial.5.2.0\lib\net40\System.Spatial.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.Abstractions">
       <Private>True</Private>
@@ -144,6 +159,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
     <Reference Include="Thinktecture.IdentityModel, Version=2.3.2.0, Culture=neutral, PublicKeyToken=0532effe7fc7da1f, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\External\Thinktecture.IdentityModel\Thinktecture.IdentityModel.dll</HintPath>

--- a/Source/Chronozoom.UI/Web.config
+++ b/Source/Chronozoom.UI/Web.config
@@ -37,11 +37,6 @@
         <add assembly="System.Data.Entity.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
       </assemblies>
     </compilation>
-    <sessionState mode="InProc" customProvider="DefaultSessionProvider">
-      <providers>
-        <add name="DefaultSessionProvider" type="System.Web.Providers.DefaultSessionStateProvider, System.Web.Providers, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
-      </providers>
-    </sessionState>
     <customErrors mode="Off" />
   </system.web>
   <system.webServer>
@@ -66,7 +61,7 @@
     <behaviors>
       <endpointBehaviors>
         <behavior name="UI.ChronozoomAspNetAjaxBehavior">
-          <webHttp defaultOutgoingResponseFormat="Json"/>
+          <webHttp defaultOutgoingResponseFormat="Json" />
         </behavior>
       </endpointBehaviors>
       <serviceBehaviors>
@@ -193,14 +188,16 @@
         <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Data.OData" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.0.0" newVersion="5.2.0.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <system.runtime.caching>
     <memoryCache>
       <namedCaches>
-        <add name="default"
-          cacheMemoryLimitMegabytes="1000"
-          pollingInterval="00:01:00" />
+        <add name="default" cacheMemoryLimitMegabytes="1000" pollingInterval="00:01:00" />
       </namedCaches>
     </memoryCache>
   </system.runtime.caching>

--- a/Source/Chronozoom.UI/packages.config
+++ b/Source/Chronozoom.UI/packages.config
@@ -13,14 +13,15 @@
   <package id="Microsoft.AspNet.WebApi.Client" version="4.0.20710.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="4.0.20710.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.WebHost" version="4.0.20710.0" targetFramework="net45" />
+  <package id="Microsoft.Data.Edm" version="5.2.0" targetFramework="net45" />
+  <package id="Microsoft.Data.OData" version="5.2.0" targetFramework="net45" />
   <package id="Microsoft.Net.Http" version="2.0.20710.0" targetFramework="net45" />
   <package id="Microsoft.Owin.Host.SystemWeb" version="1.0.0-rc2" targetFramework="net45" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
-  <package id="Microsoft.WindowsAzure.ConfigurationManager" version="1.7.0.0" targetFramework="net40" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="1.8.0.0" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />
   <package id="rx.js.TypeScript.DefinitelyTyped" version="0.0.2" targetFramework="net45" />
-  <package id="System.Web.Providers" version="1.0.1" />
-  <package id="WindowsAzure.Storage" version="1.7.0.0" targetFramework="net40" />
+  <package id="System.Spatial" version="5.2.0" targetFramework="net45" />
+  <package id="WindowsAzure.Storage" version="2.0.5.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
HotFix: Fix Azure Blob Assembly Reference.

Windows Azure Blob assemblies were added by-references, not through NuGet. Additionally, and old/incompatible version of Windows Azure Blobs was being used.

Fix was to remove reference and remove old NuGet Windows Azure Blob reference and re-add Windows Azure Blob reference. This also had the side effect of auto updating web.config and packages.config.

Verified deployment here: http://cz-july2013-javierluraschi-fixes.azurewebsites.net/
