### PR TITLE
Timeline Authoring Bug Fixes

### DIFF
--- a/Source/Chronozoom.Entities/Storage.cs
+++ b/Source/Chronozoom.Entities/Storage.cs
@@ -345,7 +345,7 @@ namespace Chronozoom.Entities
                 "SELECT * FROM Timelines WHERE Timeline_Id IN ('{0}')",
                 string.Join("', '", id));
             var timelinesRaw = Database.SqlQuery<TimelineRaw>(timelinesQuery);
-           
+
             foreach (TimelineRaw timelineRaw in timelinesRaw)
                 timelines.Add(timelineRaw.Id);
 
@@ -382,7 +382,7 @@ namespace Chronozoom.Entities
             var contentItemsRaw = Database.SqlQuery<ContentItemRaw>(contentItemsQuery);
 
             foreach (ContentItemRaw contentItemRaw in contentItemsRaw)
-                contentItems.Add(contentItemRaw.Id);      
+                contentItems.Add(contentItemRaw.Id);
             return contentItems;
         }
 
@@ -402,5 +402,13 @@ namespace Chronozoom.Entities
 
             return references;
         }
+
+        public TimelineRaw GetParentTimelineRaw(Guid timelineId)
+        {
+            var parentTimelinesRaw = Database.SqlQuery<TimelineRaw>("SELECT * FROM Timelines WHERE Id in (SELECT Timeline_Id FROM Timelines WHERE Id = {0})", timelineId);
+
+            return parentTimelinesRaw.FirstOrDefault();
+        }
+
     }
 }


### PR DESCRIPTION
Code review approved at http://mrccodereview.cloudapp.net/ui#review:id=1158

This addresses two issues tracked by:
1. https://github.com/alterm4nn/ChronoZoom/issues/242
Child timeline's start and end dates should lie within the start and end dates of their parent timeline.
1. https://github.com/alterm4nn/ChronoZoom/issues/336
   The default parent timeline for a new timeline that is created by any user defaults to the Cosmos timeline. It should default to null so timelines don't cross user boundaries + root timelines are allowed in collections other that the Beta collection.
