### PR TITLE
Analytics Improvements - Register Hash Changes

### DIFF
--- a/Source/Chronozoom.UI/cz2.html
+++ b/Source/Chronozoom.UI/cz2.html
@@ -10,13 +10,22 @@
 
         var _gaq = _gaq || [];
         _gaq.push(['_setAccount', 'UA-29180487-2']);
-        _gaq.push(['_setDomainName', 'chronozoomproject.org']);
+        _gaq.push(['_setDomainName', 'auto']);
         _gaq.push(['_setAllowLinker', true]);
         _gaq.push(['_trackPageview']);
         (function () {
             var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
             ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
             var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+
+            var lastHashData = null;
+            window.onhashchange = function () {
+                var hashData = window.location.hash.split("@")[0];
+                if (hashData !== lastHashData) {
+                    _gaq.push(['_trackEvent', 'url', 'hash', hashData, 1, lastHashData === null /* Non-Interactive*/]);
+                    lastHashData = hashData;
+                }
+            }
         })();
     </script>
 


### PR DESCRIPTION
Google Analytics Improvements

Fix 1: Send Google Analytics event to track URL hash changes. This enables answering the following question:

a) What is the correct user engagement in the site (length of visit)?
b) Which are the most popular timelines, exhibits and content items?
c) On average, how many timelines, exhibit and content items are explored per user session?

The new Google Analytics custom event details:
- Category: URL
- Action: Hash
- Label: The Hash String
- Value: 1
- Non-Interactive: Skip first hash change since it always changes after load.

Fix 2: Avoid hard-coding domain name since this is blocking the ability to filter out test.chronozoomproject.org from Google Analytics console. The code sets "_setDomainName" to auto to associate the domain dynamically.

Code Review (Approved): http://mrccodereview.cloudapp.net/ui#review:id=1156
