### PR TITLE
Sort Content Items

### DIFF
--- a/Source/Chronozoom.Entities/Storage.cs
+++ b/Source/Chronozoom.Entities/Storage.cs
@@ -143,7 +143,12 @@ namespace Chronozoom.Entities
                 // Populate Content Items
                 string contentItemsQuery = string.Format(
                     CultureInfo.InvariantCulture,
-                    "SELECT * FROM ContentItems WHERE Exhibit_Id IN ('{0}')",
+                    @"
+                        SELECT * 
+                        FROM ContentItems 
+                        WHERE Exhibit_Id IN ('{0}')
+                        ORDER BY [Order] ASC
+                    ",
                     string.Join("', '", exhibits.Keys.ToArray()));
                 var contentItemsRaw = Database.SqlQuery<ContentItemRaw>(contentItemsQuery);
                 foreach (ContentItemRaw contentItemRaw in contentItemsRaw)


### PR DESCRIPTION
Content Items are not being sorted from the SQL Layer through the API. Therefore, the main content items from each exhibit are different between test.chronozoomproject.org and www.chronozoomproject.org.

The fix is to add an ORDER BY clause to arrange by [order] field.

As a side effect: Fixes #309 and Fixes #309.

Code Review (Approved): http://mrccodereview.cloudapp.net/ui#review:id=1159
