### PR TITLE
Fix and Move Test Fallback Logic to Server

### DIFF
--- a/Source/Chronozoom.UI/Global.asax.cs
+++ b/Source/Chronozoom.UI/Global.asax.cs
@@ -19,6 +19,7 @@ using System.Web.Routing;
 using System.Web.UI;
 using System.Web.Mvc;
 using System.Text.RegularExpressions;
+using System.Collections.Generic;
 
 
 namespace Chronozoom.UI
@@ -84,8 +85,37 @@ namespace Chronozoom.UI
             var app = (HttpApplication)sender;
             if (app.Context.Request.Url.LocalPath == "/")
             {
-                app.Context.RewritePath(string.Concat(app.Context.Request.Url.LocalPath, "cz.aspx"));
+                if (BrowserIsSupported())
+                {
+                    app.Context.RewritePath(string.Concat(app.Context.Request.Url.LocalPath, "cz.aspx"));
+                }
+                else
+                {
+                    app.Context.RewritePath(string.Concat(app.Context.Request.Url.LocalPath, "fallback.html"));
+                }
             }
+        }
+
+        // Supported versions - Moved from JavaScript and added Opera
+        private static readonly Dictionary<string, int> _supportedMatrix = new Dictionary<string, int>()
+        {
+            { "IE", 9 },
+            { "Firefox", 7 },
+            { "Chrome", 14 },
+            { "Safari", 5 },
+            { "Opera", 10 },
+        };
+
+        private bool BrowserIsSupported()
+        {
+            System.Web.HttpBrowserCapabilities browser = Request.Browser;
+
+            if (_supportedMatrix.ContainsKey(browser.Browser))
+            {
+                return Double.Parse(browser.Version, System.Globalization.CultureInfo.InvariantCulture) >= _supportedMatrix[browser.Browser];
+            }
+
+            return true;
         }
     }
 }

--- a/Source/Chronozoom.UI/scripts/cz.js
+++ b/Source/Chronozoom.UI/scripts/cz.js
@@ -322,46 +322,6 @@ var CZ;
             if(!rootCollection) {
                 CZ.Authoring.isEnabled = true;
             }
-            if(navigator.userAgent.toLowerCase().indexOf('chrome') > -1) {
-                if(/Chrome[\/\s](\d+\.\d+)/.test(navigator.userAgent)) {
-                    var oprversion = new Number(RegExp.$1);
-                    if(oprversion < 14.0) {
-                        var fallback_agreement = CZ.Common.getCookie("new_bad_browser_agreement");
-                        if((fallback_agreement == null) || (fallback_agreement == "")) {
-                            window.location.href = "fallback.html";
-                            return;
-                        }
-                    }
-                }
-            } else if(navigator.userAgent.toLowerCase().indexOf('version') > -1) {
-                if(/Version[\/\s](\d+\.\d+)/.test(navigator.userAgent)) {
-                    var oprversion = new Number(RegExp.$1);
-                    if(oprversion < 5.0) {
-                        var fallback_agreement = CZ.Common.getCookie("new_bad_browser_agreement");
-                        if((fallback_agreement == null) || (fallback_agreement == "")) {
-                            window.location.href = "fallback.html";
-                            return;
-                        }
-                    }
-                }
-            } else {
-                var br = ($).browser;
-                var isIe9 = br.msie && parseInt(br.version, 10) >= 9;
-                if(!isIe9) {
-                    var isFF9 = br.mozilla && parseInt(br.version, 10) >= 7;
-                    if(!isFF9) {
-                        var is_chrome = navigator.userAgent.toLowerCase().indexOf('chrome') > -1;
-                        if(!is_chrome) {
-                            var fallback_agreement = CZ.Common.getCookie("new_bad_browser_agreement");
-                            if((fallback_agreement == null) || (fallback_agreement == "")) {
-                                window.location.href = "fallback.html";
-                                return;
-                            }
-                        }
-                        return;
-                    }
-                }
-            }
             if(navigator.userAgent.match(/(iPhone|iPod|iPad)/)) {
                 document.addEventListener('touchmove', function (e) {
                     e.preventDefault();

--- a/Source/Chronozoom.UI/scripts/cz.ts
+++ b/Source/Chronozoom.UI/scripts/cz.ts
@@ -376,49 +376,6 @@ module CZ {
             if (!rootCollection)
                 CZ.Authoring.isEnabled = true;
 
-            if (navigator.userAgent.toLowerCase().indexOf('chrome') > -1) {
-                if (/Chrome[\/\s](\d+\.\d+)/.test(navigator.userAgent)) {
-                    var oprversion = new Number(RegExp.$1) // capture x.x portion and store as a number
-                    if (oprversion < 14.0) {
-                        var fallback_agreement = CZ.Common.getCookie("new_bad_browser_agreement");
-                        if ((fallback_agreement == null) || (fallback_agreement == "")) {
-                            window.location.href = "fallback.html";
-                            return;
-                        }
-                    }
-                }
-            }
-            else if (navigator.userAgent.toLowerCase().indexOf('version') > -1) {
-                if (/Version[\/\s](\d+\.\d+)/.test(navigator.userAgent)) {
-                    var oprversion = new Number(RegExp.$1) // capture x.x portion and store as a number
-                    if (oprversion < 5.0) {
-                        var fallback_agreement = CZ.Common.getCookie("new_bad_browser_agreement");
-                        if ((fallback_agreement == null) || (fallback_agreement == "")) {
-                            window.location.href = "fallback.html";
-                            return;
-                        }
-                    }
-                }
-            }
-            else {
-                var br = (<any>$).browser;
-                var isIe9 = br.msie && parseInt(br.version, 10) >= 9;
-                if (!isIe9) {
-                    var isFF9 = br.mozilla && parseInt(br.version, 10) >= 7;
-                    if (!isFF9) {
-                        var is_chrome = navigator.userAgent.toLowerCase().indexOf('chrome') > -1;
-                        if (!is_chrome) {
-                            var fallback_agreement = CZ.Common.getCookie("new_bad_browser_agreement");
-                            if ((fallback_agreement == null) || (fallback_agreement == "")) {
-                                window.location.href = "fallback.html";
-                                return;
-                            }
-                        }
-                        return;
-                    }
-                }
-            }
-
             if (navigator.userAgent.match(/(iPhone|iPod|iPad)/)) {
                 // Suppress the default iOS elastic pan/zoom actions.
                 document.addEventListener('touchmove', function (e) { e.preventDefault(); });


### PR DESCRIPTION
Moved fallback logic (which triggers when the browser is not supported) from the client to the server. The fallback logic was broken in IE7/8 since the scripts no longer compile in IE7/8.

Code Review (Approved): http://mrccodereview.cloudapp.net/ui#review:id=1183
