### PR TITLE
Minor Root Timeline Creation Fix

### DIFF
--- a/Source/Chronozoom.UI/scripts/cz.js
+++ b/Source/Chronozoom.UI/scripts/cz.js
@@ -362,7 +362,7 @@ var CZ;
                 if(!response) {
                     canvasIsEmpty = true;
                     if(CZ.Authoring.showCreateTimelineForm) {
-                        CZ.Authoring.showCreateTimelineForm(defaultRootTimelines);
+                        CZ.Authoring.showCreateTimelineForm(defaultRootTimeline);
                     }
                 }
             });

--- a/Source/Chronozoom.UI/scripts/cz.ts
+++ b/Source/Chronozoom.UI/scripts/cz.ts
@@ -413,7 +413,7 @@ module CZ {
                 if (!response) {
                     canvasIsEmpty = true;
                     if (CZ.Authoring.showCreateTimelineForm) {
-                        CZ.Authoring.showCreateTimelineForm(defaultRootTimelines);
+                        CZ.Authoring.showCreateTimelineForm(defaultRootTimeline);
                     }
                 }
             }); //retrieving the data


### PR DESCRIPTION
There are two code paths for opening the create timeline dialog, one if the authoring UX loads before the timelines are retrieved, and the other one for the other case. Fixing typo in one code path.
