### PR TITLE
Fix Thumbnail Generation on Creation

### DIFF
--- a/Source/Chronozoom.UI/api/Chronozoom.svc.cs
+++ b/Source/Chronozoom.UI/api/Chronozoom.svc.cs
@@ -1099,8 +1099,8 @@ namespace Chronozoom.UI
                 }
                 else
                 {
-                    Guid updateContentItemGuid = UpdateContentItem(collectionGuid, contentItemRequest);
-                    returnValue = updateContentItemGuid;
+                    contentItemRequest.Id = UpdateContentItem(collectionGuid, contentItemRequest);
+                    returnValue = contentItemRequest.Id;
                 }
                 
                 _storage.SaveChanges();


### PR DESCRIPTION
Thumbnails are not generated when a content item is created, only when a content item or exhibit are modified.

The thumbnail is saved based on a GUID but the GUID is new and not assigned yet. The fix is to use the new GUID during thumbnail generation.
