### PR TITLE
Fix Redirection to cz.html

### DIFF
--- a/Source/Chronozoom.UI/scripts/urlnav.js
+++ b/Source/Chronozoom.UI/scripts/urlnav.js
@@ -152,7 +152,7 @@ var CZ;
                 };
                 if(result[4] != "") {
                     url.path = result[4].split("/");
-                    if(url.path.length >= 1 && url.path[0].length > 0) {
+                    if(url.path.length >= 1 && url.path[0].length > 0 && url.path[0] !== "cz.html") {
                         url.superCollectionName = url.path[0];
                     }
                     if(url.path.length >= 2 && url.path[1].length > 0) {

--- a/Source/Chronozoom.UI/scripts/urlnav.ts
+++ b/Source/Chronozoom.UI/scripts/urlnav.ts
@@ -239,7 +239,7 @@ module CZ {
                 if (result[4] != "") {
                     url.path = result[4].split("/");
 
-                    if (url.path.length >= 1 && url.path[0].length > 0) {
+                    if (url.path.length >= 1 && url.path[0].length > 0 && url.path[0] !== "cz.html") {
                         url.superCollectionName = url.path[0];
                     }
                     if (url.path.length >= 2 && url.path[1].length > 0) {


### PR DESCRIPTION
Navigating to cz.html gets interpreted as a superCollection by the client. The fix is for the client to ignore this path when parsing the URL.
