### PR TITLE
Fix473: Authoring blocked under supercollection URL

### DIFF
--- a/Source/Chronozoom.UI/scripts/urlnav.js
+++ b/Source/Chronozoom.UI/scripts/urlnav.js
@@ -154,6 +154,7 @@ var CZ;
                     url.path = result[4].split("/");
                     if(url.path.length >= 1 && url.path[0].length > 0 && url.path[0] !== "cz.html") {
                         url.superCollectionName = url.path[0];
+                        url.collectionName = url.superCollectionName;
                     }
                     if(url.path.length >= 2 && url.path[1].length > 0) {
                         url.collectionName = url.path[1];

--- a/Source/Chronozoom.UI/scripts/urlnav.ts
+++ b/Source/Chronozoom.UI/scripts/urlnav.ts
@@ -241,6 +241,7 @@ module CZ {
 
                     if (url.path.length >= 1 && url.path[0].length > 0 && url.path[0] !== "cz.html") {
                         url.superCollectionName = url.path[0];
+                        url.collectionName = url.superCollectionName;
                     }
                     if (url.path.length >= 2 && url.path[1].length > 0) {
                         url.collectionName = url.path[1];


### PR DESCRIPTION
Fix473: Authoring blocked under supercollection URL

The problem is that the client is not sending the default collection since the server does not support optional collection names in authoring API due to REST/WCF restrictions. Fix is to pass the default collection name based on the supercollection name.
