### PR TITLE
Fix #493: HTTP 500 error when navigating to collection

### DIFF
--- a/Source/Chronozoom.UI/api/Chronozoom.svc.cs
+++ b/Source/Chronozoom.UI/api/Chronozoom.svc.cs
@@ -1760,7 +1760,8 @@ namespace Chronozoom.UI
         private Collection RetrieveCollection(Guid collectionId)
         {
             Collection collection = _storage.Collections.Find(collectionId);
-            _storage.Entry(collection).Reference("User").Load();
+            if (collection != null)
+                _storage.Entry(collection).Reference("User").Load();
             return collection;
         }
 

--- a/Source/Chronozoom.UI/default.ashx.cs
+++ b/Source/Chronozoom.UI/default.ashx.cs
@@ -73,11 +73,11 @@ namespace Chronozoom.UI
 
             string superCollection = string.Empty;
             if (pageUrl.Segments.Length >= 2)
-                superCollection = pageUrl.Segments[1].Substring(0, pageUrl.Segments[1].Length - 1);
+                superCollection = pageUrl.Segments[1].Split('/')[0];
 
             string collection = superCollection;
             if (pageUrl.Segments.Length >= 3)
-                collection = pageUrl.Segments[2].Substring(0, pageUrl.Segments[2].Length - 1);
+                collection = pageUrl.Segments[2].Split('/')[0];
 
             Timeline timeline = ChronozoomSVC.Instance.GetTimelines(superCollection, collection, null, null, null, null, null, "1");
             if (timeline != null)


### PR DESCRIPTION
HTTP 500 error when navigating to collection. 

Failing to parse collection/supercolleciton from URL when trailing '/' is missing. Fix it to split URL by '/' and avoid loading user form collection that does not exists.
