### PR TITLE
Fix #482: Incorrect validation fires when creating a timelines

### DIFF
--- a/Source/Chronozoom.UI/cz.js
+++ b/Source/Chronozoom.UI/cz.js
@@ -8175,9 +8175,10 @@ var CZ;
                 if(!this.validateNumber(year)) {
                     return false;
                 }
+                year = parseInt(year);
                 var month = this.monthSelector.find(":selected").val();
                 month = CZ.Dates.months.indexOf(month);
-                var day = this.daySelector.find(":selected").val();
+                var day = parseInt(this.daySelector.find(":selected").val());
                 return CZ.Dates.getCoordinateFromDMY(year, month, day);
             };
             DatePicker.prototype.validateNumber = function (year) {

--- a/Source/Chronozoom.UI/ui/controls/datepicker.js
+++ b/Source/Chronozoom.UI/ui/controls/datepicker.js
@@ -192,9 +192,10 @@ var CZ;
                 if(!this.validateNumber(year)) {
                     return false;
                 }
+                year = parseInt(year);
                 var month = this.monthSelector.find(":selected").val();
                 month = CZ.Dates.months.indexOf(month);
-                var day = this.daySelector.find(":selected").val();
+                var day = parseInt(this.daySelector.find(":selected").val());
                 return CZ.Dates.getCoordinateFromDMY(year, month, day);
             };
             DatePicker.prototype.validateNumber = function (year) {

--- a/Source/Chronozoom.UI/ui/controls/datepicker.ts
+++ b/Source/Chronozoom.UI/ui/controls/datepicker.ts
@@ -301,10 +301,11 @@ module CZ {
                 var year = this.yearSelector.val();
                 if (!this.validateNumber(year))
                     return false;
+                year = parseInt(year);
 
                 var month = this.monthSelector.find(":selected").val();
                 month = CZ.Dates.months.indexOf(month);
-                var day = this.daySelector.find(":selected").val();
+                var day = parseInt(this.daySelector.find(":selected").val());
 
                 return <any>CZ.Dates.getCoordinateFromDMY(year, month, day);
             }


### PR DESCRIPTION
Fix #482: https://github.com/alterm4nn/ChronoZoom/issues/482

Missing to parse string as int while getting date from UI elements.
