### PR TITLE
Remove debug prompt and bring back full JS list in localhost

### DIFF
--- a/Source/Chronozoom.UI/api/Chronozoom.svc.cs
+++ b/Source/Chronozoom.UI/api/Chronozoom.svc.cs
@@ -196,8 +196,6 @@ namespace Chronozoom.UI
         // The Maximum number of elements retured in a Search
         private const int MaxSearchLimit = 50;
       
-        
-
         // error code descriptions
         private static class ErrorDescription
         {
@@ -229,27 +227,14 @@ namespace Chronozoom.UI
             public const string BookmarkSequenceIdInvalid = "Bookmark sequence id is invalid";
         }
 
-        private static Lazy<string> _hostPath = new Lazy<string>(() =>
+        private static Lazy<ChronozoomSVC> _sharedService = new Lazy<ChronozoomSVC>(() =>
         {
-            Uri uri = HttpContext.Current.Request.Url;
-            return uri.Scheme + Uri.SchemeDelimiter + uri.Host + ":" + uri.Port;
-        });
-
-        private static Lazy<IChronozoomSVC> _chronozoomService = new Lazy<IChronozoomSVC>(() =>
-        {
-            WebHttpBinding myBinding = new WebHttpBinding();
-            myBinding.MaxReceivedMessageSize = 100000000;
-
-            EndpointAddress myEndpoint = new EndpointAddress(_hostPath.Value + "/api/chronozoom.svc");
-
-            ChannelFactory<IChronozoomSVC> factory = new ChannelFactory<IChronozoomSVC>(myBinding, myEndpoint);
-            factory.Endpoint.Behaviors.Add(new WebHttpBehavior());
-            return factory.CreateChannel();
+            return new ChronozoomSVC();
         });
 
         internal static IChronozoomSVC Instance
         {
-            get { return _chronozoomService.Value; }
+            get { return _sharedService.Value; }
         }
 
         /// <summary>

--- a/Source/Chronozoom.UI/cz.html
+++ b/Source/Chronozoom.UI/cz.html
@@ -45,11 +45,61 @@
     <script type="text/javascript" src="/scripts/external/seadragon-min.js"></script>
 
     <script type="text/javascript">
-        if (Modernizr.canvas) {
+        function AddScript(path) {
             var script = document.createElement("script");
             script.type = "text/javascript";
-            script.src = "/cz.js";
+            script.src = path;
             document.getElementsByTagName("head")[0].appendChild(script);
+        }
+
+        if (Modernizr.canvas) {
+            if (constants.environment == 'Localhost') {
+                AddScript("/scripts/settings.js");
+                AddScript("/scripts/common.js");
+                AddScript("/scripts/viewport.js");
+                AddScript("/scripts/viewport-animation.js");
+                AddScript("/scripts/gestures.js");
+                AddScript("/scripts/virtual-canvas.js");
+                AddScript("/scripts/vccontent.js");
+                AddScript("/scripts/viewport-controller.js");
+                AddScript("/scripts/urlnav.js");
+                AddScript("/scripts/layout.js");
+                AddScript("/scripts/tours.js");
+                AddScript("/scripts/search.js");
+                AddScript("/scripts/bibliography.js");
+                AddScript("/scripts/breadcrumbs.js");
+
+                AddScript("/scripts/authoring.js");
+                AddScript("/scripts/authoring-ui.js");
+                AddScript("/scripts/service.js");
+                AddScript("/scripts/data.js");
+                AddScript("/scripts/timescale.js");
+                AddScript("/scripts/uiloader.js");
+                AddScript("/scripts/dates.js");
+
+                AddScript("/ui/controls/datepicker.js");
+                AddScript("/ui/controls/listboxbase.js");
+                AddScript("/ui/controls/formbase.js");
+                AddScript("/ui/contentitem-listbox.js");
+                AddScript("/ui/auth-edit-timeline-form.js");
+                AddScript("/ui/auth-edit-exhibit-form.js");
+                AddScript("/ui/auth-edit-contentitem-form.js");
+                AddScript("/ui/auth-edit-tour-form.js");
+                AddScript("/ui/header-edit-form.js");
+                AddScript("/ui/header-edit-profile-form.js");
+                AddScript("/ui/header-login-form.js");
+                AddScript("/ui/header-logout-form.js");
+                AddScript("/ui/timeseries-data-form.js");
+                AddScript("/ui/timeseries-graph-form.js");
+                AddScript("/ui/tour-listbox.js");
+                AddScript("/ui/tourlist-form.js");
+                AddScript("/ui/tourstop-listbox.js");
+                
+                AddScript("/scripts/cz.js");
+            }
+            else {
+                AddScript("/cz.js");
+            }
         }
         else {
             window.location = "/fallback.html"


### PR DESCRIPTION
Remove debug prompt and bring back full JS list in localhost. Fix https://github.com/alterm4nn/ChronoZoom/issues/536

Added a JavaScript environment variable that can take the { localhost, test, production } values. This is used to decide to load all the script files or the single cz.js one.

Changed pages to API interactions ot be in-proc to improve performance and avoid debugging  prompts.
