### PR TITLE
[HotFix] Disable Progressive Load Migration

### DIFF
--- a/Source/Chronozoom.UI/api/Chronozoom.svc.cs
+++ b/Source/Chronozoom.UI/api/Chronozoom.svc.cs
@@ -311,10 +311,6 @@ namespace Chronozoom.UI
             if (rootTimeline == null)
                 return true;
 
-            // Allow code to revalidate counts since zero count could mean old timeline
-            if (rootTimeline.SubtreeSize == 0)
-                return false;
-
             if (rootTimeline.SubtreeSize < maxElements)
                 return true;
 


### PR DESCRIPTION
[HotFix] Disable Progressive Load Migration

Problem: Code was added to perform in-place migrations for progressive loading; however, code proved insufficient for huge collections. Therefore, the code was reverted to instead perform in a next check-in a migration based on a storedproc. The code that got checked-in in was verified against several collections, including energy, beta-content, aids-timeline, etc. However, the DB from this environment already contained the migrated data to progressive load and therefore, they rendered correctly. Unfortunately, the test-environment database did not contained the migrated database content and the timelines started failing.
