### PR TITLE
Fix #566: Create artifact loads the wrong image

### DIFF
--- a/Source/Chronozoom.UI/cz.js
+++ b/Source/Chronozoom.UI/cz.js
@@ -6401,10 +6401,6 @@ var CZ;
             var point = CZ.Common.getXBrowserMouseOrigin(container, e);
             var k = (_range.max - _range.min) / _width;
             var time = _range.max - k * (_width - point.x);
-            var test1 = CZ.Dates.getCoordinateFromYMD(1, 0, 1);
-            var test2 = CZ.Dates.getYMDFromCoordinate(test1);
-            var test3 = CZ.Dates.convertCoordinateToYear(test1);
-            console.log(test1, test2, test3);
             if(time <= _range.min + CZ.Settings.panelWidth * k) {
                 marker.css("display", "none");
                 LeftPanInput();

--- a/Source/Chronozoom.UI/ui/auth-edit-contentitem-form.js
+++ b/Source/Chronozoom.UI/ui/auth-edit-contentitem-form.js
@@ -67,7 +67,7 @@ var CZ;
                 var _this = this;
                 var newContentItem = {
                     title: this.titleInput.val() || "",
-                    uri: this.mediaInput.val() || "",
+                    uri: decodeURIComponent(this.mediaInput.val()) || "",
                     mediaSource: this.mediaSourceInput.val() || "",
                     mediaType: this.mediaTypeInput.val() || "",
                     attribution: this.attributionInput.val() || "",

--- a/Source/Chronozoom.UI/ui/auth-edit-contentitem-form.ts
+++ b/Source/Chronozoom.UI/ui/auth-edit-contentitem-form.ts
@@ -105,7 +105,7 @@ module CZ {
             private onSave() {
                 var newContentItem = {
                     title: this.titleInput.val() || "",
-                    uri: this.mediaInput.val() || "",
+                    uri: decodeURIComponent(this.mediaInput.val()) || "",
                     mediaSource: this.mediaSourceInput.val() || "",
                     mediaType: this.mediaTypeInput.val() || "",
                     attribution: this.attributionInput.val() || "",


### PR DESCRIPTION
Fix #566: Create artifact loads the wrong image

Rendering code assumes that the URL are not-encoded and encodes them during run-time (for instance, when vccontent passes them to seadragonServiceUrl). Therefore, the fix is to decode URLs that are added through the authoring UI.
