### PR TITLE
ToursBug625 SequenceId unchanged

### DIFF
--- a/Source/Chronozoom.UI/api/Chronozoom.svc.cs
+++ b/Source/Chronozoom.UI/api/Chronozoom.svc.cs
@@ -1288,7 +1288,7 @@ namespace Chronozoom.UI
                 newTour.Collection = collection;
 
                 storage.Tours.Add(newTour);
-		storage.SaveChanges();
+                storage.SaveChanges();
                 returnValue.TourId = newTourGuid;
 
                 // Populate the bookmarks.
@@ -1389,15 +1389,19 @@ namespace Chronozoom.UI
                 return Guid.Empty;
             }
 
-            storage.Entry(updateTour).Collection(_ => _.Bookmarks).Load();
-            if (updateTour.Bookmarks != null)
+            // If the bookmark sequence id is unchanged then skip the uniqueness test.
+            if (updateBookmark.SequenceId != bookmarkRequest.SequenceId)
             {
-                List<Bookmark> bookmarkList = updateTour.Bookmarks.ToList();
-                Bookmark sequenceIdBookmark = bookmarkList.Where(candidate => candidate.SequenceId == bookmarkRequest.SequenceId).FirstOrDefault();
-                if (sequenceIdBookmark != null)
+                storage.Entry(updateTour).Collection(_ => _.Bookmarks).Load();
+                if (updateTour.Bookmarks != null)
                 {
-                    SetStatusCode(HttpStatusCode.BadRequest, ErrorDescription.BookmarkSequenceIdDuplicate);
-                    return Guid.Empty;
+                    List<Bookmark> bookmarkList = updateTour.Bookmarks.ToList();
+                    Bookmark sequenceIdBookmark = bookmarkList.Where(candidate => candidate.SequenceId == bookmarkRequest.SequenceId).FirstOrDefault();
+                    if (sequenceIdBookmark != null)
+                    {
+                        SetStatusCode(HttpStatusCode.BadRequest, ErrorDescription.BookmarkSequenceIdDuplicate);
+                        return Guid.Empty;
+                    }
                 }
             }
 


### PR DESCRIPTION
GitHub issue: https://github.com/alterm4nn/ChronoZoom/issues/625

This addresses the first part of the issue where when a bookmark is updated, if it sequence id is unaltered since other fields could be modified, the PUT Tours call should update the bookmark.

The second part will be addressed as part of the changes for https://github.com/alterm4nn/ChronoZoom/issues/592
