### PR TITLE
Bug #586: Creation of several content items for one time

### DIFF
--- a/Source/Chronozoom.UI/scripts/authoring.js
+++ b/Source/Chronozoom.UI/scripts/authoring.js
@@ -334,41 +334,31 @@ var CZ;
             CZ.VCContent.removeChild(t.parent, t.id);
         }
         Authoring.removeTimeline = removeTimeline;
-        function updateExhibit(e, args) {
+        function updateExhibit(oldExhibit, args) {
             var deferred = $.Deferred();
-            if(e && e.contentItems && args) {
-                var clone = $.extend({
-                }, e, {
+            if(oldExhibit && oldExhibit.contentItems && args) {
+                var newExhibit = $.extend({
+                }, oldExhibit, {
                     children: null
                 });
-                clone = $.extend(true, {
-                }, clone);
-                delete clone.children;
-                delete clone.contentItems;
-                $.extend(true, clone, args);
-                var oldContentItems = $.extend(true, [], e.contentItems);
-                CZ.Service.putExhibit(clone).then(function (response) {
-                    var old_id = e.id;
-                    e.id = clone.id = "e" + response.ExhibitId;
-                    var new_id = e.id;
-                    e.guid = clone.guid = response.ExhibitId;
-                    for(var i = 0; i < e.contentItems.length; i++) {
-                        e.contentItems[i].ParentExhibitId = e.guid;
+                newExhibit = $.extend(true, {
+                }, newExhibit);
+                delete newExhibit.children;
+                delete newExhibit.contentItems;
+                $.extend(true, newExhibit, args);
+                CZ.Service.putExhibit(newExhibit).then(function (response) {
+                    newExhibit.guid = response.ExhibitId;
+                    for(var i = 0; i < newExhibit.contentItems.length; i++) {
+                        newExhibit.contentItems[i].ParentExhibitId = newExhibit.guid;
                     }
-                    for(var i = 0; i < clone.contentItems.length; i++) {
-                        clone.contentItems[i].ParentExhibitId = clone.guid;
-                    }
-                    CZ.Service.putExhibitContent(clone, oldContentItems).then(function (response) {
-                        $.extend(e, clone);
-                        e.id = old_id;
-                        e = renewExhibit(e);
-                        e.id = new_id;
-                        CZ.Common.vc.virtualCanvas("requestInvalidate");
-                        deferred.resolve();
-                    }, function (error) {
-                        console.log("Error connecting to service: update exhibit (put exhibit content).\n" + error.responseText);
-                        deferred.reject();
+                    $(response.ContentItemId).each(function (contentItemIdIndex, contentItemId) {
+                        newExhibit.contentItems[contentItemIdIndex].id = contentItemId;
+                        newExhibit.contentItems[contentItemIdIndex].guid = contentItemId;
                     });
+                    newExhibit = renewExhibit(newExhibit);
+                    newExhibit.id = "e" + response.ExhibitId;
+                    CZ.Common.vc.virtualCanvas("requestInvalidate");
+                    deferred.resolve();
                 }, function (error) {
                     console.log("Error connecting to service: update exhibit.\n" + error.responseText);
                     deferred.reject();

--- a/Source/Chronozoom.UI/scripts/authoring.ts
+++ b/Source/Chronozoom.UI/scripts/authoring.ts
@@ -557,45 +557,34 @@ module CZ {
          * @param  {Object} e    An exhibit to update.
          * @param  {Object} args An object with properties' values.
          */
-        export function updateExhibit(e, args) {
+        export function updateExhibit(oldExhibit, args) {
             var deferred = $.Deferred();
 
-            if (e && e.contentItems && args) {
-                var clone: any = $.extend({}, e, { children: null }); // shallow copy of exhibit (without children)
-                clone = $.extend(true, {}, clone); // deep copy exhibit
-                delete clone.children;
-                delete clone.contentItems;
-                $.extend(true, clone, args); // overwrite and append properties
-
-                var oldContentItems = $.extend(true, [], e.contentItems);
+            if (oldExhibit && oldExhibit.contentItems && args) {
+                var newExhibit: any = $.extend({}, oldExhibit, { children: null }); // shallow copy of exhibit (without children)
+                newExhibit = $.extend(true, {}, newExhibit); // deep copy exhibit
+                delete newExhibit.children;
+                delete newExhibit.contentItems;
+                $.extend(true, newExhibit, args); // overwrite and append properties
 
                 // pass cloned objects to CZ.Service calls to avoid any side effects
-                CZ.Service.putExhibit(clone).then(
+                CZ.Service.putExhibit(newExhibit).then(
                     response => {
-                        var old_id = e.id;
-                        e.id = clone.id = "e" + response.ExhibitId;
-                        var new_id = e.id;
-                        e.guid = clone.guid = response.ExhibitId;
-                        for (var i = 0; i < e.contentItems.length; i++) {
-                            e.contentItems[i].ParentExhibitId = e.guid;
+                        newExhibit.guid = response.ExhibitId;
+                        for (var i = 0; i < newExhibit.contentItems.length; i++) {
+                            newExhibit.contentItems[i].ParentExhibitId = newExhibit.guid;
                         }
-                        for (var i = 0; i < clone.contentItems.length; i++) {
-                            clone.contentItems[i].ParentExhibitId = clone.guid;
-                        }
-                        CZ.Service.putExhibitContent(clone, oldContentItems).then(
-                            response => {
-                                $.extend(e, clone);
-                                e.id = old_id;
-                                e = renewExhibit(e);
-                                e.id = new_id;
-                                CZ.Common.vc.virtualCanvas("requestInvalidate");
-                                deferred.resolve();
-                            },
-                            error => {
-                                console.log("Error connecting to service: update exhibit (put exhibit content).\n" + error.responseText);
-                                deferred.reject();
-                            }
-                        );
+
+                        $(response.ContentItemId).each(function (contentItemIdIndex, contentItemId) {
+                            newExhibit.contentItems[contentItemIdIndex].id = contentItemId;
+                            newExhibit.contentItems[contentItemIdIndex].guid = contentItemId;
+                        });
+
+                        newExhibit = renewExhibit(newExhibit);
+                        newExhibit.id = "e" + response.ExhibitId;
+
+                        CZ.Common.vc.virtualCanvas("requestInvalidate");
+                        deferred.resolve();
                     },
                     error => {
                         console.log("Error connecting to service: update exhibit.\n" + error.responseText);

--- a/Source/Chronozoom.UI/scripts/bibliography.js
+++ b/Source/Chronozoom.UI/scripts/bibliography.js
@@ -7,7 +7,7 @@ var CZ;
                 pendingBibliographyForExhibitID = null;
                 $("#bibliographyBack").hide('clip', {
                 }, 'slow');
-                window.location.hash = window.location.hash.replace(new RegExp("&b=[a-z0-9_]+$", "gi"), "");
+                window.location.hash = window.location.hash.replace(new RegExp("&b=[a-z0-9_\-]+$", "gi"), "");
             });
         }
         Bibliography.initializeBibliography = initializeBibliography;
@@ -21,7 +21,7 @@ var CZ;
             }
             var vp = CZ.Common.vc.virtualCanvas("getViewport");
             var nav = CZ.UrlNav.vcelementToNavString(element, vp);
-            if(window.location.hash.match("b=([a-z0-9_]+)") == null) {
+            if(window.location.hash.match("b=([a-z0-9_\-]+)") == null) {
                 var bibl = "&b=" + id;
                 if(window.location.hash.indexOf('@') == -1) {
                     bibl = "@" + bibl;

--- a/Source/Chronozoom.UI/scripts/service.js
+++ b/Source/Chronozoom.UI/scripts/service.js
@@ -51,6 +51,21 @@ var CZ;
                 };
             }
             Map.exhibit = exhibit;
+            function exhibitWithContentItems(e) {
+                var mappedContentItems = [];
+                $(e.contentItems).each(function (contentItemIndex, contentItem) {
+                    mappedContentItems.push(Map.contentItem(contentItem));
+                });
+                return {
+                    id: e.guid,
+                    ParentTimelineId: e.parent.guid,
+                    time: e.infodotDescription.date,
+                    title: e.title,
+                    description: undefined,
+                    contentItems: mappedContentItems
+                };
+            }
+            Map.exhibitWithContentItems = exhibitWithContentItems;
             function contentItem(ci) {
                 return {
                     id: ci.guid,
@@ -226,7 +241,7 @@ var CZ;
                 contentType: "application/json",
                 dataType: "json",
                 url: request.url,
-                data: JSON.stringify(Map.exhibit(e))
+                data: JSON.stringify(Map.exhibitWithContentItems(e))
             });
         }
         Service.putExhibit = putExhibit;

--- a/Source/Chronozoom.UI/scripts/service.ts
+++ b/Source/Chronozoom.UI/scripts/service.ts
@@ -59,6 +59,22 @@ module CZ {
                 };
             }
 
+            export function exhibitWithContentItems(e) {
+                var mappedContentItems = [];
+                $(e.contentItems).each(function (contentItemIndex, contentItem) {
+                    mappedContentItems.push(Map.contentItem(contentItem))
+                });
+
+                return {
+                    id: e.guid,
+                    ParentTimelineId: e.parent.guid,
+                    time: e.infodotDescription.date,
+                    title: e.title,
+                    description: undefined,
+                    contentItems: mappedContentItems
+                };
+            }
+
             export function contentItem(ci) {
                 return {
                     id: ci.guid,
@@ -278,7 +294,7 @@ module CZ {
                 contentType: "application/json",
                 dataType: "json",
                 url: request.url,
-                data: JSON.stringify(Map.exhibit(e))
+                data: JSON.stringify(Map.exhibitWithContentItems(e))
             });
         }
 


### PR DESCRIPTION
Code Review: http://mrccodereview.cloudapp.net/ui#review:id=1255

Creating or updating an exhibit with multiple content items causes the client to perform multiple calls to the server (one per content item). Instead, add support in the PutExhibit API to support in-place edits of content items and modify the client code to perform a single call.
