### PR TITLE
Bug 566: Create Artifact Loads the Wrong Image

### DIFF
--- a/Source/Chronozoom.UI/Dumps/aidstimeline-get.json
+++ b/Source/Chronozoom.UI/Dumps/aidstimeline-get.json
@@ -7,7 +7,7 @@
                 "description" : "AIDS is the leading cause of death for all Americans ages 25 to 44. While the demand for treatment has never been higher, medical researchers are unable to develop more effective drugs.  The search for a vaccine continues to elude the efforts of medical researchers.",
                 "id" : "fd48616f-8506-459d-8e06-147a47d0b93c",
                 "mediaSource" : " http://thegrio.com/2011/06/01/slideshow-30-years-of-hivaids-in-black-america/",
-                "mediaType" : "Picture",
+                "mediaType" : "DeepImage",
                 "parentExhibitId" : "33f837cf-beef-451c-b856-0d96efb81eaf",
                 "title" : "Facing AIDS",
                 "uri" : "http://czbeta.blob.core.windows.net/images/5ce6e695-660f-4bb9-aa95-f9291cde660c_1994_Essence_Cover.jpeg"
@@ -18,7 +18,7 @@
                 "description" : "The CDC launches the first condom ads to air on US television.  The photograph above shows a CDC safe sex campaign poster from 1989.",
                 "id" : "68e06232-1852-4827-85e8-3f80ef3430e2",
                 "mediaSource" : "http://profiles.nlm.nih.gov/ps/retrieve/Narrative/VC/p-nid/129/p-visuals/true",
-                "mediaType" : "Picture",
+                "mediaType" : "DeepImage",
                 "parentExhibitId" : "33f837cf-beef-451c-b856-0d96efb81eaf",
                 "title" : "Safe Sex Campaign on TV",
                 "uri" : "http://czbeta.blob.core.windows.net/images/d1143215-e2d8-4f9b-bccb-32701ca01231_1994_Safe_Sex.jpg"
@@ -29,7 +29,7 @@
                 "description" : "Pedro Zamora, a young gay man living with HIV, appears on the cast of MTV’s popular show, “The Real World.” One day after the season finale, he dies at the age of 22.",
                 "id" : "1576be1c-8e49-4a5a-be9a-2358dce389bd",
                 "mediaSource" : "http://projectqatlanta.com/news_articles/view/lgbt_history_month_lee_daniels_trans_victory?gid=9364",
-                "mediaType" : "Picture",
+                "mediaType" : "DeepImage",
                 "parentExhibitId" : "33f837cf-beef-451c-b856-0d96efb81eaf",
                 "title" : "AIDS on Television",
                 "uri" : "http://czbeta.blob.core.windows.net/images/63554465-d19c-4652-a148-ee0a3f6bad4b_1994_AIDS_on_television.jpg"
@@ -40,7 +40,7 @@
                 "description" : "The CDC adds three new conditions—pulmonary tuberculosis, recurrent pneumonia, and\r\ninvasive cervical cancer—to the list of clinical indicators of AIDS. The inclusion\r\nof these new conditions mean that more women and injection drug users will be\r\ndiagnosed with AIDS.",
                 "id" : "5e3aa88c-abbd-4d60-b86e-78ab73312b5e",
                 "mediaSource" : "time.com",
-                "mediaType" : "Picture",
+                "mediaType" : "DeepImage",
                 "parentExhibitId" : "33f837cf-beef-451c-b856-0d96efb81eaf",
                 "title" : "Diagnosis Criteria Encompasses Wider Demographic",
                 "uri" : "http://czbeta.blob.core.windows.net/images/aaefab23-c425-4524-bdb8-4db3214243a0_1994_Time-AIDSLosingBattle.jpg"
@@ -51,7 +51,7 @@
                 "description" : "The activist group ACT-UP and Benetton put a giant condom on the Place de Concorde in Paris.\r\n",
                 "id" : "bbdeb58c-d81a-46d9-acab-fe3acbc40caa",
                 "mediaSource" : "http://www.webmd.com/hiv-aids/ss/slideshow-aids-retrospective",
-                "mediaType" : "Picture",
+                "mediaType" : "DeepImage",
                 "parentExhibitId" : "33f837cf-beef-451c-b856-0d96efb81eaf",
                 "title" : "International Awareness Campaign",
                 "uri" : "http://czbeta.blob.core.windows.net/images/39df249e-6e03-42e1-9f0f-4f643b2f2c23_1994_giant_condom_in_paris.jpeg"
@@ -62,7 +62,7 @@
                 "description" : "Angels in America, Tony Kushner’s play about AIDS, wins the Tony Award for Best Play and the 1993 Pulitzer Prize for Drama.\r\n",
                 "id" : "27c6bf8b-1fe1-4d5b-ac38-e1e32343afb0",
                 "mediaSource" : "http://www.hbo.com/assets/images/movies/angels-in-america/downloads/wallpaper-angel-1600.jpg",
-                "mediaType" : "Picture",
+                "mediaType" : "DeepImage",
                 "parentExhibitId" : "33f837cf-beef-451c-b856-0d96efb81eaf",
                 "title" : "AIDS and the Arts",
                 "uri" : "http://czbeta.blob.core.windows.net/images/526f615b-7f7c-4d64-8881-8ea12141ecba_1994_angels-in-america.jpg"
@@ -79,7 +79,7 @@
                 "description" : "People living with AIDS (PLWAs) take over the plenary stage at the Second National AIDS Forum in Denver, and issue a statement on the right of PLWAs to be at the table when policy is made, to be treated with dignity, and to be called “people with AIDS,” not “AIDS victims.” The statement becomes known as “The Denver Principles,” and it serves as the charter for the founding of the National Association of People with AIDS  (NAPWA).",
                 "id" : "4bf377d8-2b71-4595-b936-b65533129295",
                 "mediaSource" : "http://www.bilerico.com/2010/05/are_you_in_the_fight_to_end_aids.php",
-                "mediaType" : "Picture",
+                "mediaType" : "DeepImage",
                 "parentExhibitId" : "50f4a262-2f12-4fb6-9b6d-a46b07911d22",
                 "title" : "Activism for PLWAs' rights",
                 "uri" : "http://czbeta.blob.core.windows.net/images/762c93db-fb56-4cb0-aa5e-55d34eaf6445_1983_Fighting for our Lives.jpg"
@@ -90,7 +90,7 @@
                 "description" : "Pasteur Institute researchers Luc Montagnier and Francoise Barre-Sinoussi isolate a\r\nvirus from the swollen lymph gland of a person with AIDS. They called it\r\nlymphadenopathy-associated virus or LAV. Independently, Jay Levy, a researcher at\r\nthe University of California, San Francisco isolates a virus called AIDS-related\r\nvirus or ARV.  It isn't until 1986 that the medical community agrees to call the\r\nvirus human immunodeficiency virus or HIV.",
                 "id" : "a6befada-2e55-447d-aaaa-8d3a863bbbac",
                 "mediaSource" : "http://www.webmd.com/hiv-aids/ss/slideshow-aids-retrospective",
-                "mediaType" : "Picture",
+                "mediaType" : "DeepImage",
                 "parentExhibitId" : "50f4a262-2f12-4fb6-9b6d-a46b07911d22",
                 "title" : "Identification of HIV",
                 "uri" : "http://czbeta.blob.core.windows.net/images/cd0516b2-7157-40e1-919a-fc2915492ad5_1983_discovery-of-HIV.jpg"
@@ -101,7 +101,7 @@
                 "description" : "In a September  publication, the CDC identifies the major routes of HIV\r\ntransmission, and rules out transmission by casual contact, food, water, air, or\r\nenvironmental surfaces. The CDC offers the initial warning that AIDS may spread by\r\nheterosexual sex and by mother-to-child transmission.",
                 "id" : "90a762f0-f97a-4f5a-bda6-9e4807982f53",
                 "mediaSource" : "http://www.avert.org",
-                "mediaType" : "Picture",
+                "mediaType" : "DeepImage",
                 "parentExhibitId" : "50f4a262-2f12-4fb6-9b6d-a46b07911d22",
                 "title" : "Transmission Mode Identified",
                 "uri" : "http://czbeta.blob.core.windows.net/images/906a6f70-9feb-4286-8c90-d26d2cece0c5_1983_none-of-these-will-give-you-aids-poster.jpg"
@@ -112,7 +112,7 @@
                 "description" : "Public apprehension spreads based on lack of knowledge and incomplete communication\r\nfrom government health officials. Rumors circulate of \"household spread\" -- the\r\nbelief that simply sharing living space with someone who is infected with HIV can\r\nlead to infection. In New York, some landlords start to evict PLWAs (people living\r\nwith AIDS).",
                 "id" : "38dee850-becc-451d-a112-b2745d27d5c7",
                 "mediaSource" : "http://www.time.com/time/covers/0,16641,19830704,00.html",
-                "mediaType" : "Picture",
+                "mediaType" : "DeepImage",
                 "parentExhibitId" : "50f4a262-2f12-4fb6-9b6d-a46b07911d22",
                 "title" : "Fear and Misunderstanding Spread",
                 "uri" : "http://czbeta.blob.core.windows.net/images/d8a16f1c-37f0-4284-8f97-e26241944f1d_1983_Time_AIDS_Hysteria.jpg"
@@ -123,7 +123,7 @@
                 "description" : "The heterosexual spread of AIDS in Africa is confirmed.",
                 "id" : "156c6b1c-5bcb-4351-8d2f-b59d8820ac21",
                 "mediaSource" : "http://www.webmd.com/hiv-aids/ss/slideshow-aids-retrospective",
-                "mediaType" : "Picture",
+                "mediaType" : "DeepImage",
                 "parentExhibitId" : "50f4a262-2f12-4fb6-9b6d-a46b07911d22",
                 "title" : " Epidemic in Africa",
                 "uri" : "http://czbeta.blob.core.windows.net/images/0a92c0a5-b40b-48c5-a349-9970a1112dcb_1983_Epidemic-In-Africa.jpg"
@@ -140,7 +140,7 @@
                 "description" : "The red ribbon, designed by the New York-based Visual AIDS Artists Caucus, is introduced as an international symbol of AIDS solidarity. According to Frank Moore of Visual AIDS, the color red was chosen for its \"connection to blood and the idea of passion - not only anger, but love, like a valentine.\"",
                 "id" : "fe044aa4-44bb-4b3a-88ff-01829024816c",
                 "mediaSource" : "http://rivergrandrapids.com/have-you-noticed-people-wearing-red-ribbons-today-all-over-town/",
-                "mediaType" : "Picture",
+                "mediaType" : "DeepImage",
                 "parentExhibitId" : "573d9a92-e503-4928-96da-2609b9ad9532",
                 "title" : "An International Symbol",
                 "uri" : "http://czbeta.blob.core.windows.net/images/e979282d-eda9-490b-bf7c-25e8cc252495_1991_red_ribbon.jpg"
@@ -151,7 +151,7 @@
                 "description" : "According to the CDC, deaths caused by HIV infection were the third leading cause of death among persons aged 25-44 years. The death rate for HIV infection for men of this age group was seven times that for women.  After 1995, the rates started increasing for women, by 1996, the rate of death in women from HIV became much higher than the death rate for men.\r\n",
                 "id" : "2b5f67c3-aebd-444b-a60e-395aaa9525b6",
                 "mediaSource" : "http://history-is-made-at-night.blogspot.com/2010/12/world-aids-day.html",
-                "mediaType" : "Picture",
+                "mediaType" : "DeepImage",
                 "parentExhibitId" : "573d9a92-e503-4928-96da-2609b9ad9532",
                 "title" : "Leading cause of death for US men 25-44 years old",
                 "uri" : "http://czbeta.blob.core.windows.net/images/d4fe96d1-b093-4d4d-9f3c-99239c22a1cb_1991_Blood-On-Hands.jpg"
@@ -162,7 +162,7 @@
                 "description" : "American basketball star Earvin “Magic” Johnson announces that he is HIV-positive.\r\nThe lead singer for the British rock band Queen, Freddy Mercury, dies of AIDS.",
                 "id" : "45ce7d6b-cdd7-43e1-85ae-ecda704a0601",
                 "mediaSource" : "http://the4thquarter.net/2009/06/16/kobe-bryant-on-sports-illustrated/http://www.followingthenerd.com/ftn_news/the-queen-director-linked-to-freddie-mercury-biopic/",
-                "mediaType" : "Picture",
+                "mediaType" : "DeepImage",
                 "parentExhibitId" : "573d9a92-e503-4928-96da-2609b9ad9532",
                 "title" : "Celebrities with AIDS",
                 "uri" : "http://czbeta.blob.core.windows.net/images/873a3443-1e2f-4e6e-af44-328f3f190dc9_1991_MagicJhonson-FreddieMercury.jpg"
@@ -173,7 +173,7 @@
                 "description" : "The previous year, ACT UP protests at the National Institutes of Health (NIH), demanding the expansion of clinical trials to include more women and people of color.",
                 "id" : "f310cac7-b293-4297-8103-719bfcb4bc3c",
                 "mediaSource" : "http://www.flickriver.com/photos/genyphyr/1357127406/",
-                "mediaType" : "Picture",
+                "mediaType" : "DeepImage",
                 "parentExhibitId" : "573d9a92-e503-4928-96da-2609b9ad9532",
                 "title" : "Demand for More Representative Clinical Trials",
                 "uri" : "http://czbeta.blob.core.windows.net/images/f7e4daf9-0f66-4ccc-95e5-be9dfeed91a5_1991_More_Representative_Clinical_Trials.jpg"
@@ -190,7 +190,7 @@
                 "description" : "The number of reported AIDS cases in the United States reaches 100,000.\r\nACT UP protests shut down the FDA. Within a week, the FDA begins a \"fast-track\" policy allowing public access to lifesaving drugs still in clinical trials.",
                 "id" : "1874cb82-9fb5-469e-8efe-7a1892cefda8",
                 "mediaSource" : "http://www.webmd.com/hiv-aids/ss/slideshow-aids-retrospective",
-                "mediaType" : "Picture",
+                "mediaType" : "DeepImage",
                 "parentExhibitId" : "5b9dd9a1-fc29-4ab4-90ef-bede1fc75d7d",
                 "title" : "100,000 Afflicted",
                 "uri" : "http://czbeta.blob.core.windows.net/images/ce459a01-6e33-40b8-83bb-a49b7b7d34da_1988_100000affilcted.jpg"
@@ -201,7 +201,7 @@
                 "description" : "Scientists determine that even before AIDS symptoms develop, HIV replicates wildly\r\nin the blood. The goal of treatment shifts to keeping HIV at low levels.  The term\r\n\"T-Cells\" enters into popular conversation.",
                 "id" : "28c4e748-7981-4033-a811-bf429b423ccb",
                 "mediaSource" : "http://hardinmd.lib.uiowa.edu/cdc/948.html",
-                "mediaType" : "Picture",
+                "mediaType" : "DeepImage",
                 "parentExhibitId" : "5b9dd9a1-fc29-4ab4-90ef-bede1fc75d7d",
                 "title" : "New Approach to Treatment",
                 "uri" : "http://czbeta.blob.core.windows.net/images/8fa41b21-d208-4518-a1d2-dc8c4038ec30_1988_HIV virus.jpg"
@@ -212,7 +212,7 @@
                 "description" : "The first World AIDS Day is held on Dec. 1, 1988.  The event was first conceived in\r\nAugust 1987 by James W. Bunn and Thomas Netter, two public information officers for\r\nthe Global Program on AIDS at the World Health Organization in Geneva, Switzerland. \r\nTheir objective was to use the day to publicize the rate of HIV/AIDS infection\r\naround the globe and to promote educational efforts to stop the spread of HIV.",
                 "id" : "3bbfc096-d099-45ae-951e-715c122de022",
                 "mediaSource" : "http://www.thesinglegirlsguidetomen.com/relaxation/wellness/safe-sex-aids",
-                "mediaType" : "Picture",
+                "mediaType" : "DeepImage",
                 "parentExhibitId" : "5b9dd9a1-fc29-4ab4-90ef-bede1fc75d7d",
                 "title" : "First World AIDS Day",
                 "uri" : "http://czbeta.blob.core.windows.net/images/80970a5f-f684-498f-bb02-e376f1feeed0_1988_world_AIDS_day.jpg"
@@ -223,7 +223,7 @@
                 "description" : "Under the direction of the Surgeon General of the US, C. Everette Koop, a pamphlet\r\ntitled \"Understanding AIDS\" was mailed to every household in the US: 107 million\r\ncopies. As he wrote in the original report: \"We are fighting a disease, not people.\"\r\nThis pamphlet and Koop's prior longer report on HIV infection was an attempt to\r\nshift the US national dialogue about AIDS from a focus on identity (homosexuality)\r\nto a discussion of safer sex practices.",
                 "id" : "c7864696-3c09-4bf2-9d00-6fcbf555ba7a",
                 "mediaSource" : "http://colorlines.com/archives/2011/11/does_todays_generation_of_young_men_need_a_magic_johnson_to_save_them.html",
-                "mediaType" : "Picture",
+                "mediaType" : "DeepImage",
                 "parentExhibitId" : "5b9dd9a1-fc29-4ab4-90ef-bede1fc75d7d",
                 "title" : "Message from the US Surgeon General ",
                 "uri" : "http://czbeta.blob.core.windows.net/images/c9855603-e39f-4f24-b1c5-bc0e8a363b49_1988_Surgeon-General.jpg"
@@ -234,7 +234,7 @@
                 "description" : "American photographer, Robert Mapplethorpe, dies from AIDS at the age of 42. His\r\nwork was controversial at the time for its homoerotic content, and consequently\r\nprovoked heated debate over the public funding of art. Thi  self-portrait was made\r\nin 1988, a year before his death.",
                 "id" : "f4d8e3aa-6a4b-4587-9355-7262570c0f60",
                 "mediaSource" : "http://arteseanp.blogspot.com/2010/12/robert-mapplethorpe.html",
-                "mediaType" : "Picture",
+                "mediaType" : "DeepImage",
                 "parentExhibitId" : "5b9dd9a1-fc29-4ab4-90ef-bede1fc75d7d",
                 "title" : "Photographer Robert Mapplethorpe Dies of AIDS",
                 "uri" : "http://czbeta.blob.core.windows.net/images/bbf8f92a-92ac-415b-8675-143813529be9_1988_mapplethorpe.jpg"
@@ -245,7 +245,7 @@
                 "description" : "The Joint United Nations Programm on HIV/AIDS (UNAIDS) reports that the number of\r\nwomen living with HIV/AIDS in sub-Saharan Africa exceeds that of men.",
                 "id" : "2bd984b7-9959-494d-80d5-a4f07bbc9274",
                 "mediaSource" : "http://fansinaflashbulb.wordpress.com/2011/12/01/world-aids-day-3/1053_2000/",
-                "mediaType" : "Picture",
+                "mediaType" : "DeepImage",
                 "parentExhibitId" : "5b9dd9a1-fc29-4ab4-90ef-bede1fc75d7d",
                 "title" : "Increasing Numbers of Women Infected with HIV",
                 "uri" : "http://czbeta.blob.core.windows.net/images/80c8d207-c9c1-4146-80be-736eeade5d43_1988_Women-get-AIDS.jpeg"
@@ -262,7 +262,7 @@
                 "description" : "The CDC calls the new disease:  Acquired Immune Deficiency Syndrome or AIDS. The CDC\r\nestimates that tens of thousands of people may be affected by the disease.",
                 "id" : "e70d6b68-bcb6-4541-a733-ed84b0e499af",
                 "mediaSource" : "time.com",
-                "mediaType" : "Picture",
+                "mediaType" : "DeepImage",
                 "parentExhibitId" : "68cef42f-a508-4102-bf45-92750e015ff2",
                 "title" : "\"AIDS\"",
                 "uri" : "http://czbeta.blob.core.windows.net/images/b3e6254b-bba3-45a6-b8ea-03bfbb8c93c8_1982_Time-AIDSwhat'sbeingdone.jpg"
@@ -273,7 +273,7 @@
                 "description" : "AIDS is seen in people with hemophilia, convincing scientists that the disease is spread by an infectious agent in contaminated blood.",
                 "id" : "e5285928-db23-4612-aabf-7fa8c88c3ed0",
                 "mediaSource" : "http://www.thirdage.com/image/blood-transfusion-procedure",
-                "mediaType" : "Picture",
+                "mediaType" : "DeepImage",
                 "parentExhibitId" : "68cef42f-a508-4102-bf45-92750e015ff2",
                 "title" : "First Hemophiliac Cases Reported",
                 "uri" : "http://czbeta.blob.core.windows.net/images/5fa7832a-9ec9-4e3c-8f3b-edcb682ce922_1982_blood-transfusion-procedure.jpg"
@@ -284,7 +284,7 @@
                 "description" : "On December 10, CDC reports a case of AIDS in an infant who received blood transfusions. The following week, the Morbidity and Mortality Weekly Report (MMWR) reports 22 cases of unexplained immunodeficiency and opportunistic infections in infants.",
                 "id" : "244de99d-c50c-467a-be33-f3c648e43334",
                 "mediaSource" : "http://www.webmd.com/hiv-aids/ss/slideshow-aids-retrospective",
-                "mediaType" : "Picture",
+                "mediaType" : "DeepImage",
                 "parentExhibitId" : "68cef42f-a508-4102-bf45-92750e015ff2",
                 "title" : "First Infant Cases Reported",
                 "uri" : "http://czbeta.blob.core.windows.net/images/7e9a3c2c-6901-4cc1-9416-3445f1af0066_1982_AIDS_baby_1983.jpg"
@@ -295,7 +295,7 @@
                 "description" : "In April , U.S. Representative Henry Waxman convenes the first congressional\r\nhearings on HIV/AIDS. In this photograph, three AIDS activists are sworn in before a\r\nHouse Governmental Relations subcommittee hearing on Capitol Hill to study\r\nstrategies for dealing with the fatal disease.  Left to right: Michael Callen (New\r\nYork), Roger Lyon (San Francisco), and Anthony Ferrara (Washington).",
                 "id" : "b410d5c3-6659-4cde-b0cd-2d215cec9877",
                 "mediaSource" : "http://www.theatlantic.com/politics/archive/2011/06/the-heroic-story-of-how-congress-first-confronted-aids/240131/",
-                "mediaType" : "Picture",
+                "mediaType" : "DeepImage",
                 "parentExhibitId" : "68cef42f-a508-4102-bf45-92750e015ff2",
                 "title" : "First Congressional hearings",
                 "uri" : "http://czbeta.blob.core.windows.net/images/5add0201-148a-4b16-86bd-c374a00902f6_1982_Congressional_Hearing.jpg"
@@ -306,7 +306,7 @@
                 "description" : "Gay Men’s Health Crisis, the first community-based AIDS service provider in the U.S., is founded in New York City.\r\nIn January, the first AIDS clinic in the United States is established in San Francisco.",
                 "id" : "68b965f2-8756-4a20-9dc9-b69a55b04e91",
                 "mediaSource" : "http://www.nytimes.com/slideshow/2008/07/08/nyregion/08-center_9.html",
-                "mediaType" : "Picture",
+                "mediaType" : "DeepImage",
                 "parentExhibitId" : "68cef42f-a508-4102-bf45-92750e015ff2",
                 "title" : "First Community Care Providers",
                 "uri" : "http://czbeta.blob.core.windows.net/images/160289bf-261b-42c5-9c72-4ed4bdc84fd9_1982_GayMenHealth.JPG"
@@ -323,7 +323,7 @@
                 "description" : "In June 2011 3,000 people participate in the United Nation’s (UN) High-Level Meeting\r\non HIV/AIDS in New York. The session recognizes critical milestones, including three\r\ndecades of the pandemic and the 10-year anniversary of the 2001 UN General Assembly\r\nSpecial Session on HIV/AIDS and the resulting Declaration of Commitment. At the\r\nMeeting, the U.S. joined with other partners in launching a global plan to eliminate\r\nmother-to-child transmission of HIV and keep mothers alive.",
                 "id" : "c17df268-88c0-4b5d-aeaf-2da1c9853db7",
                 "mediaSource" : "http://www.christianpost.com/news/world-aids-day-2011-america-pledges-50m-more-to-fight-aids-video-63753/",
-                "mediaType" : "Picture",
+                "mediaType" : "DeepImage",
                 "parentExhibitId" : "6cb67643-fb17-406f-8294-9bdf6be36d6b",
                 "title" : "Global Plan to End Mother-to-Child Transmission",
                 "uri" : "http://czbeta.blob.core.windows.net/images/aa03e28d-fba2-456c-b501-2fb2a8e69a85_2011-red-ribbon-white-house.jpeg"
@@ -334,7 +334,7 @@
                 "description" : " Medical researchers have identified more than a dozen antibodies that target the HIV virus.  This provides hope that they can create a vaccine that offers long-term protection against AIDS. One antibody in particular, PGT 128, is considered among the most potent and promising.  In laboratory tests, it is shown to prevent 70% of viruses from infecting cells. This HIV-neutralizing antibody may lead to new vaccines.",
                 "id" : "5939f7f2-d2a0-41e3-b02d-2ef323e4a27d",
                 "mediaSource" : "http://www.webmd.com/hiv-aids/ss/slideshow-aids-retrospective",
-                "mediaType" : "Picture",
+                "mediaType" : "DeepImage",
                 "parentExhibitId" : "6cb67643-fb17-406f-8294-9bdf6be36d6b",
                 "title" : "Hope for a Vaccine",
                 "uri" : "http://czbeta.blob.core.windows.net/images/5ebddc06-33ed-423c-9a66-13967f1361cc_2011_hope-for-a-vaccine.jpg"
@@ -356,7 +356,7 @@
                 "description" : "On September 30, the first Road to AIDS 2012 Town Hall meeting kicks off in San\r\nFrancisco. This is the first of 15 meetings to be held across the country, leading\r\nup to the XIX International AIDS Conference (AIDS 2012), to be held July 22-27,\r\n2012, in Washington, DC.",
                 "id" : "13a2d1c1-e3a1-4be9-af23-4d6458453060",
                 "mediaSource" : "http://www.time.com/time/covers/0,16641,19850812,00.html",
-                "mediaType" : "Picture",
+                "mediaType" : "DeepImage",
                 "parentExhibitId" : "6cb67643-fb17-406f-8294-9bdf6be36d6b",
                 "title" : "Road to AIDS 2012",
                 "uri" : "http://czbeta.blob.core.windows.net/images/04a95eba-4494-4f17-8783-6290f218359e_2011_Road-to-AIDS.jpg"
@@ -373,7 +373,7 @@
                 "description" : "The American Foundation for AIDS Research (amFAR) is founded to raise funds from\r\nprivate sources to support medical research on HIV/AIDS.  Elizabeth Taylor becomes\r\nthe Foundation's spokeswoman. A scathing government report blasts the United States\r\nDepartment of Health and Human Services for not providing adequate funds for medical\r\nresearch on HIV/AIDS.",
                 "id" : "7fd0c12d-395a-4e62-ae38-662ffc6cac9e",
                 "mediaSource" : "http://blogs.newzealand.usembassy.gov/ambassador/tag/hiv/",
-                "mediaType" : "Picture",
+                "mediaType" : "DeepImage",
                 "parentExhibitId" : "860ad31d-74c3-4bde-a9af-5269eeeca13d",
                 "title" : "Foundation Established to Raise Research Funds",
                 "uri" : "http://czbeta.blob.core.windows.net/images/3377b51c-a64b-4f06-89eb-1bbac7cc5ff4_1985_Taylor_amFAR.jpg"
@@ -384,7 +384,7 @@
                 "description" : "The Secretary of the US Department of Health and Human Services, announces that\r\nRobert Gallo and his colleagues at the National Cancer Institute have isolated the\r\ncause of AIDS:  the retrovirus HTLV-III.   Also announced is the development of a\r\ndiagnostic blood test to identify HTLV-III.  Many people express hope that a vaccine\r\nagainst AIDS will be produced within two years.",
                 "id" : "37047915-6e85-4ba7-987e-fd2542d03142",
                 "mediaSource" : "http://www.webmd.com/hiv-aids/ss/slideshow-aids-retrospective",
-                "mediaType" : "Picture",
+                "mediaType" : "DeepImage",
                 "parentExhibitId" : "860ad31d-74c3-4bde-a9af-5269eeeca13d",
                 "title" : "Retrovirus Identified",
                 "uri" : "http://czbeta.blob.core.windows.net/images/08cac139-4940-4824-a5c8-3deb8b8e249a_1985_Retrovirus-Identified.jpg"
@@ -395,7 +395,7 @@
                 "description" : "The US Food and Drug Administration (FDA) licenses the first commercial blood test,\r\nELISA, that detect antibodies to HIV.  For the first time, blood banks begin\r\nscreening the US blood supply.",
                 "id" : "eef54db0-2241-4e4b-b6f0-c59ddeeb52a9",
                 "mediaSource" : "http://www.vancouversun.com/index.html",
-                "mediaType" : "Picture",
+                "mediaType" : "DeepImage",
                 "parentExhibitId" : "860ad31d-74c3-4bde-a9af-5269eeeca13d",
                 "title" : "First Commercial Blood Test Available",
                 "uri" : "http://czbeta.blob.core.windows.net/images/3e271dbc-9eab-4220-8ab3-36a90bbf6507_1985_blood-test.jpeg"
@@ -406,7 +406,7 @@
                 "description" : "In 1985, the First International AIDS Conference is held in Atlanta. By this date,\r\nevery region of the world reports at least one HIV case.",
                 "id" : "ff4633dc-39f6-47b5-9465-cfb9f4c43543",
                 "mediaSource" : "http://ja.wikipedia.org/wiki/%E3%83%95%E3%82%A1%E3%82%A4%E3%83%AB:Atlanta_skyline_with_sports_complexes.JPEG",
-                "mediaType" : "Picture",
+                "mediaType" : "DeepImage",
                 "parentExhibitId" : "860ad31d-74c3-4bde-a9af-5269eeeca13d",
                 "title" : "First International AIDS Conference",
                 "uri" : "http://czbeta.blob.core.windows.net/images/b0d7e04a-8313-4d5f-8592-1d67e4d3c632_1985_Atlanta_skyline.JPG"
@@ -417,7 +417,7 @@
                 "description" : "In 1986, as AIDS hysteria builds through the US, Ryan White, an Indiana teenager who\r\ncontracted AIDS through contaminated blood products used to treat his hemophilia, is\r\nbarred from school.  He sued for the right to return to school; this photograph\r\nshows him after the announcement that he could go back to classes.",
                 "id" : "5c68d2cb-6970-49ce-8e94-cc10dd99c573",
                 "mediaSource" : "http://www.webmd.com/hiv-aids/ss/slideshow-aids-retrospective",
-                "mediaType" : "Picture",
+                "mediaType" : "DeepImage",
                 "parentExhibitId" : "860ad31d-74c3-4bde-a9af-5269eeeca13d",
                 "title" : "Ryan White Barred From School",
                 "uri" : "http://czbeta.blob.core.windows.net/images/aa9cf908-8496-4e5d-9bf5-4f6c43a0e0b0_1985__ryan_white.jpg"
@@ -428,7 +428,7 @@
                 "description" : "Rock Hudson is one of the first major Hollywood stars to die of AIDS-related\r\ncomplications. At first, the popular media reported that he had liver cancer, but he\r\nlater admitted that his illness was due to AIDS. This disclosure not only revealed\r\nhis homosexuality but had an immediate impact on the visibility of AIDS among the\r\ngeneral US population.  This recognition spurred increases in funding for medical\r\nresearch related to the disease.",
                 "id" : "a0f9ddb6-61f9-45d7-9f75-3f487da415d4",
                 "mediaSource" : "http://www.webmd.com/hiv-aids/ss/slideshow-aids-retrospective",
-                "mediaType" : "Picture",
+                "mediaType" : "DeepImage",
                 "parentExhibitId" : "860ad31d-74c3-4bde-a9af-5269eeeca13d",
                 "title" : "Rock Hudson Dies of AIDS",
                 "uri" : "http://czbeta.blob.core.windows.net/images/67ca5a0f-cad6-4e8d-9e97-8b11063b867d_1985_Rock-Hudson.jpg"
@@ -445,7 +445,7 @@
                 "description" : "UNAIDS calculates that the global spread of AIDS peaked in 1996 at 3.5 million new\r\ninfections. Deaths peaked in 2004, at 2.2 million.  But by 2009, the figures are\r\nstill grim:  2.7 million new HIV infections and 2 million AIDS deaths in 2008.  Half\r\nof those who need it get no treatment.  Polls show most Americans no longer consider\r\nAIDS a major problem.  They're wrong.   African Americans -- 12% of the U.S.\r\npopulation -- get 45% of new HIV infections.",
                 "id" : "3c40eec1-0cff-4bac-b1cd-c6cab6bc895d",
                 "mediaSource" : "http://www.webmd.com/hiv-aids/ss/slideshow-aids-retrospective",
-                "mediaType" : "Picture",
+                "mediaType" : "DeepImage",
                 "parentExhibitId" : "a89eddbf-ec67-4468-8bfd-c9fb4b44077f",
                 "title" : "Still an Epidemic, Many Untreated",
                 "uri" : "http://czbeta.blob.core.windows.net/images/1d776552-e89f-4d28-90b0-20f91f172a90_2009_AIDS-still-a-crisis.jpg"
@@ -456,7 +456,7 @@
                 "description" : " Of the 33 million people now living with HIV, 3 million are getting treatment. That's less than a third of those who need immediate treatment. Yet for the first time, global AIDS deaths decline.",
                 "id" : "0237c683-c595-4eb0-9795-8e65e7afab77",
                 "mediaSource" : "http://www.thehindu.com/health/article2675546.ece",
-                "mediaType" : "Picture",
+                "mediaType" : "DeepImage",
                 "parentExhibitId" : "a89eddbf-ec67-4468-8bfd-c9fb4b44077f",
                 "title" : "Global AIDS Deaths Decline",
                 "uri" : "http://czbeta.blob.core.windows.net/images/e6ad264d-1262-4985-9ec1-6b50c83e4231_2009_Fight_Stigma-end-AIDS.jpg"
@@ -467,7 +467,7 @@
                 "description" : "Luc Montagnier and Francoise Barre-Sinoussi awarded Nobel Prize in medicine for discovery of HIV.",
                 "id" : "44587d61-b95a-484e-afde-5b7cedfa0b15",
                 "mediaSource" : "http://www.webmd.com/hiv-aids/ss/slideshow-aids-retrospective",
-                "mediaType" : "Picture",
+                "mediaType" : "DeepImage",
                 "parentExhibitId" : "a89eddbf-ec67-4468-8bfd-c9fb4b44077f",
                 "title" : "Nobel Prize Awarded",
                 "uri" : "http://czbeta.blob.core.windows.net/images/39c8dc09-aeab-4841-aa39-41bb85813b2f_2009_recognition_medical_breakthrough.jpg"
@@ -478,7 +478,7 @@
                 "description" : "In 2009, black women accounted for 30% of new HIV infections among all blacks in the US.  Estimated rate of new HIV infections for black women was more than 15 times as high as the rate for white women, and more that three times as high as that of Latina women.",
                 "id" : "ad712fb5-247f-4ebc-bbe6-0dd84ab80ca3",
                 "mediaSource" : "http://www.opednews.com/articles/Black-women-and-AIDS-Fix-by-Kathlyn-Stone-081214-942.html",
-                "mediaType" : "Picture",
+                "mediaType" : "DeepImage",
                 "parentExhibitId" : "a89eddbf-ec67-4468-8bfd-c9fb4b44077f",
                 "title" : "African-American Women at Highest Risk ",
                 "uri" : "http://czbeta.blob.core.windows.net/images/83dbaf3b-d6c3-4e69-bd9e-6a9a6665d483_2009_African-american-women-risk.jpg"
@@ -489,7 +489,7 @@
                 "description" : "Health officials report that Washington, DC has a higher rate of HIV (3% prevalence) than West Africa – enough to describe it as a “severe and generalized epidemic.” The White House and the CDC launch the Act Against AIDS campaign, a communication campaign designed to reduce HIV incidence in the United States. The CDC also launches the Act Against AIDS Leadership Initiative (AAALI), to harness the collective strength and reach of traditional, longstanding African American institutions to increase awareness, knowledge, and action within Black communities across the U.S.\r\n",
                 "id" : "679b31b2-43e0-4b10-b099-a4a5b3f82902",
                 "mediaSource" : "http://www.webmd.com/hiv-aids/ss/slideshow-aids-retrospective",
-                "mediaType" : "Picture",
+                "mediaType" : "DeepImage",
                 "parentExhibitId" : "a89eddbf-ec67-4468-8bfd-c9fb4b44077f",
                 "title" : "Addressing Communities",
                 "uri" : "http://czbeta.blob.core.windows.net/images/946b5622-ce96-4134-bf9d-ff611d62b846_2009_adressing_communities.jpg"
@@ -500,7 +500,7 @@
                 "description" : "US President Barack Obama announces that his administration will officially lift the\r\nHIV travel and immigration ban in January 2010. The lifting of the travel ban occurs\r\nin conjunction with the announcement that the International AIDS Conference will\r\nreturn to the United States in 2012 for the first time in more than 20 years.",
                 "id" : "9c53af02-4739-4b96-9de1-490fda10bef4",
                 "mediaSource" : "http://vermontcares.files.wordpress.com/2008/07/travel-ban.jpg",
-                "mediaType" : "Picture",
+                "mediaType" : "DeepImage",
                 "parentExhibitId" : "a89eddbf-ec67-4468-8bfd-c9fb4b44077f",
                 "title" : "Lift of Immigration Ban",
                 "uri" : "http://czbeta.blob.core.windows.net/images/da3a865f-6b83-4222-bada-5e05b0b50385_2009_TravelBanLifted.jpg"
@@ -517,7 +517,7 @@
                 "description" : "The US Food and Drug Administration (FDA) approves the first antiretroviral drug,\r\nzidovudine, commonly referred to as AZT.  The activist group called AIDS Coalition\r\nto Unleash Power (ACT-UP) forms to protest the $10,000 per year cost of the AZT\r\ntreatment. It adopts the motto:  SILENCE=DEATH. The US Congress approves $30 million\r\nin emergency funding to states to subsidize the purchase of AZT for people who are\r\ninfected with HIV.  This lays the groundwork for what will known as the AIDS Drug\r\nAssistance Program (ADAP) that is authorized by the Ryan White CARE Act in 1990.",
                 "id" : "dcf2a059-d2e1-4a9e-8030-cd4766a67458",
                 "mediaSource" : "http://www.webmd.com/hiv-aids/ss/slideshow-aids-retrospective",
-                "mediaType" : "Picture",
+                "mediaType" : "DeepImage",
                 "parentExhibitId" : "b05fb139-b70a-424d-9749-95d0bdee3e9d",
                 "title" : "ACT-UP  Protests Cost of AZT",
                 "uri" : "http://czbeta.blob.core.windows.net/images/8d437949-56c0-4c4c-9a75-2827993428ac_1987_Silence_Death.jpg"
@@ -528,7 +528,7 @@
                 "description" : "For the first time, President Reagan makes a speech about AIDS. Although AIDS was\r\nfirst identified in 1981, Reagan did not mention it publicly for several years until\r\na press conference he gave in 1985.\r\n",
                 "id" : "cc5e7557-2fc0-4113-a621-b7d828e845e1",
                 "mediaSource" : "http://timelines.latimes.com/aids/",
-                "mediaType" : "Picture",
+                "mediaType" : "DeepImage",
                 "parentExhibitId" : "b05fb139-b70a-424d-9749-95d0bdee3e9d",
                 "title" : "First Public Acknowledgement by US President",
                 "uri" : "http://czbeta.blob.core.windows.net/images/6fcfcf36-c18a-43ac-a144-b378ac69badf_1987_Reagan.jpg"
@@ -539,7 +539,7 @@
                 "description" : "After Florida’s Desoto County School Board refuses to allow HIV-positive brothers,\r\nRicky, Robert, and Randy Ray to attend school, a Federal judge orders the board to\r\nreinstate the three hemophiliacs, who contracted HIV through contaminated blood\r\nproducts. After the August ruling, outraged town residents refuse to allow their\r\nchildren to attend school, and someone sets fire to the Ray house on August 28,\r\ndestroying it.",
                 "id" : "5da179e0-e236-4b11-8c2b-be9b71f1676f",
                 "mediaSource" : "http://blackrajaa.blogspot.com/2011/06/aids-30-years-history.html",
-                "mediaType" : "Picture",
+                "mediaType" : "DeepImage",
                 "parentExhibitId" : "b05fb139-b70a-424d-9749-95d0bdee3e9d",
                 "title" : "Ray Brothers Ruling",
                 "uri" : "http://czbeta.blob.core.windows.net/images/00f12dd3-58c7-4eb0-8cf6-55329cec6242_1987_Ray-Brothers.jpg"
@@ -550,7 +550,7 @@
                 "description" : "Princess Diana makes international headlines by embracing AIDS patients in the UK. \r\nIn response to the outrage, she states:  \"HIV does not make people dangerous to\r\nknow, so you can shake their hands or give them a hug. Heaven knows they need it.”\r\nIn her work with an international AIDS charity, she was one of  first public figures\r\nin Britain to attempt to stop the stigmatization of AIDS patients.",
                 "id" : "386680f6-9bf6-4dda-8e52-8008bd32d808",
                 "mediaSource" : "http://www.webmd.com/hiv-aids/ss/slideshow-aids-retrospective",
-                "mediaType" : "Picture",
+                "mediaType" : "DeepImage",
                 "parentExhibitId" : "b05fb139-b70a-424d-9749-95d0bdee3e9d",
                 "title" : "AIDS as an International Cause",
                 "uri" : "http://czbeta.blob.core.windows.net/images/c41487a4-0827-4a4d-b09b-29ae5c9a945e_1987_Princess_Diana.jpg"
@@ -561,7 +561,7 @@
                 "description" : "The US forbids immigration by people infected with HIV. Under legislation enacted by\r\nthe US Congress in 1993, people found importing anti-HIV medication into the country\r\nwere arrested and immediately deported back to their country of origin.",
                 "id" : "f51caf42-f50c-4a2c-89b9-195fa1a63314",
                 "mediaSource" : "http://www.frankjump.com/stamp5.html",
-                "mediaType" : "Picture",
+                "mediaType" : "DeepImage",
                 "parentExhibitId" : "b05fb139-b70a-424d-9749-95d0bdee3e9d",
                 "title" : "US Immigration Ban",
                 "uri" : "http://czbeta.blob.core.windows.net/images/efaa7c30-657f-4e02-8d15-e6184cd3c838_1987_Immigration-Ban.jpg"
@@ -578,7 +578,7 @@
                 "description" : "Medical researchers develop a new treatment approach referred to as an AIDS drug\r\n\"cocktail\".  It consists of a combination of drugs.  Called highly active\r\nanti-retroviral therapy or HAART, the treatment can cut HIV viral load to\r\nundetectable levels.  Hope surges when AIDS researcher David Ho, MD, suggests\r\ntreatment could eliminate HIV from the body.  He's wrong -- it's later found that\r\nHIV hides in dormant cells.  In one year, deaths from AIDS in the US decline by more\r\nthan 40%.",
                 "id" : "9433ac5e-8c7b-4a58-8717-ffa4ebc54fc2",
                 "mediaSource" : "http://www.webmd.com/hiv-aids/ss/slideshow-aids-retrospective",
-                "mediaType" : "Picture",
+                "mediaType" : "DeepImage",
                 "parentExhibitId" : "b71839cd-e548-447c-a127-1478de37191a",
                 "title" : "HAART",
                 "uri" : "http://czbeta.blob.core.windows.net/images/79a63441-ba0c-4306-9133-a79899ae2653_1996_Time_cover_HAART.jpg"
@@ -594,7 +594,7 @@
                 "description" : "AIDS becomes the leading cause of death worldwide for people aged 15 to 59. ",
                 "id" : "2d531180-dbb6-41a9-93ae-88f34e083774",
                 "mediaSource" : "http://ufvcascade.ca/2010/11/11/afrigrand-tackles-aids-in-africa/",
-                "mediaType" : "Picture",
+                "mediaType" : "DeepImage",
                 "parentExhibitId" : "c09fe0af-dfab-4f8b-a25a-9de02f7446ab",
                 "title" : "Know Your Status",
                 "uri" : "http://czbeta.blob.core.windows.net/images/edb93023-7623-4e62-8d52-3cb0bbce0a70_2002_Know-your_HIV_status.jpg"
@@ -605,7 +605,7 @@
                 "description" : "Awareness grows that HAART has serious side effects. Increasing evidence of drug resistance also calls into question the “hit early, hit hard” strategy.\r\n\r\nIn the ensuing years, the FDA approves new classes of drugs that make HIV treatment safer, easier, and more effective. But the drugs still do not cure AIDS.",
                 "id" : "40033fc5-13b3-4075-9e4d-cfb68fa3a697",
                 "mediaSource" : "http://www.webmd.com/hiv-aids/ss/slideshow-aids-retrospective",
-                "mediaType" : "Picture",
+                "mediaType" : "DeepImage",
                 "parentExhibitId" : "c09fe0af-dfab-4f8b-a25a-9de02f7446ab",
                 "title" : "Beyond HAART",
                 "uri" : "http://czbeta.blob.core.windows.net/images/3a84d7d8-2e52-4478-8c4c-feee92c0ab54_2002_Beyond-HAART.jpg"
@@ -616,7 +616,7 @@
                 "description" : "After generic drug manufacturers agree to produce discounted, generic forms of\r\nHIV/AIDS drugs for developing countries, several major pharmaceutical manufacturers\r\nalso agree reduce drug prices to those countries.  The Joint United Nations Program\r\non HIV/AIDS (UNAIDS), along with the World Health Organization (WHO), and other\r\nglobal health groups announce a joint initiative with five major pharmaceutical\r\nmanufacturers to negotiate reduced prices for HIV/AIDS drugs in developing\r\ncountries.",
                 "id" : "ec9a7ff7-3a18-444a-ac36-706d714ca665",
                 "mediaSource" : "http://www.webmd.com/hiv-aids/ss/slideshow-aids-retrospective",
-                "mediaType" : "Picture",
+                "mediaType" : "DeepImage",
                 "parentExhibitId" : "c09fe0af-dfab-4f8b-a25a-9de02f7446ab",
                 "title" : "Generic AIDS Drugs Reach the World Market ",
                 "uri" : "http://czbeta.blob.core.windows.net/images/5080f68e-8304-465c-a617-fdd80da64839_2002_Drugs-reach-world-market.jpg"
@@ -627,7 +627,7 @@
                 "description" : "In 2000, President Clinton issues an Executive Order to assist developing countries in importing and producing generic HIV treatments.",
                 "id" : "1a1c0579-7faa-4201-b705-103705dc36e0",
                 "mediaSource" : "http://www.globalenvision.org/files/capetown.jpg",
-                "mediaType" : "Picture",
+                "mediaType" : "DeepImage",
                 "parentExhibitId" : "c09fe0af-dfab-4f8b-a25a-9de02f7446ab",
                 "title" : "International Outreach ",
                 "uri" : "http://czbeta.blob.core.windows.net/images/31836d9a-7b33-47fe-9525-76b8821695a5_2002_International-Outreach.jpg"
@@ -638,10 +638,10 @@
                 "description" : "In 2003, President Bush announces the $15 billion President's Emergency Plan for AIDS Relief. The prevention portion of the plan is criticized for over-emphasis on abstinence. But the plan provides much-needed HIV/AIDS-treatment funds to 15 nations.",
                 "id" : "f48cb38d-c75d-4132-a7df-6f6529c11ffa",
                 "mediaSource" : "http://www.avert.org/media-gallery/image-1536-an-hiv-positive-woman-and-her-baby-with-a-co-blister-pack-of-antiretroviral-medication",
-                "mediaType" : "Picture",
+                "mediaType" : "DeepImage",
                 "parentExhibitId" : "c09fe0af-dfab-4f8b-a25a-9de02f7446ab",
                 "title" : "PEPFAR",
-                "uri" : "picture"
+                "uri" : "DeepImage"
               },
               { "Order" : 6,
                 "Year" : 2002.0,
@@ -649,7 +649,7 @@
                 "description" : "The 14th International AIDS Conference is held in Barcelona, Spain in 2002. Dozens of countries report they are experiencing serious HIV/AIDS epidemics, and many more are on the brink.",
                 "id" : "9abbfcc5-ab0f-459e-9db9-8973f7c22bc1",
                 "mediaSource" : "http://the-aids-pandemic.blogspot.com/2008_08_01_archive.html",
-                "mediaType" : "Picture",
+                "mediaType" : "DeepImage",
                 "parentExhibitId" : "c09fe0af-dfab-4f8b-a25a-9de02f7446ab",
                 "title" : "The Epidemic Becomes a Pandemic",
                 "uri" : "http://czbeta.blob.core.windows.net/images/ab18460d-77fe-4993-a567-cb98b750443b_2002_AIDS_becomes_Pandemic.jpg"
@@ -660,7 +660,7 @@
                 "description" : "UN Secretary General Kofi Annan proposes the Global Fund to Fight HIV/AIDS, TB and\r\nMalaria. The purpose of the Global Fund is to mobilize, manage, and distribute funds\r\nto fight the pandemic of infectious diseases. Treatment is still totally unavailable\r\nto the vast majority of people living with HIV throughout the globe. Only 1% of the\r\n4.1 million sub-Saharan Africans with HIV receive anti-HIV drugs.  The above\r\nphotograph show an aerial view of a graveyard in South Africa, where 250,000 died of\r\nAIDS in a single year.",
                 "id" : "efe81127-7391-4c1a-a41c-350e1a8fe2d7",
                 "mediaSource" : "http://www.webmd.com/hiv-aids/ss/slideshow-aids-retrospective",
-                "mediaType" : "Picture",
+                "mediaType" : "DeepImage",
                 "parentExhibitId" : "c09fe0af-dfab-4f8b-a25a-9de02f7446ab",
                 "title" : "Developing Nations Demand Access to Treatment",
                 "uri" : "http://czbeta.blob.core.windows.net/images/49a4d14e-a003-4965-9dfe-39f7948efbfa_2002_developing_countries_demand_treatment.jpg"
@@ -677,7 +677,7 @@
                 "description" : "In June, the Center for Disease Control (CDC) in the US publishes a report about\r\nfive young homosexual men with life-threatening PCP pneumonia.  In July, the CDC\r\nreports that an unusual skin cancer -- Kaposi's sarcoma -- is killing young,\r\npreviously healthy men in New York City and California.  These symptoms would later\r\nbecome recognized as \"opportunistic diseases\" associated with HIV infection. By\r\nyear-end, there is a cumulative total of 270 reported cases of severe immune\r\ndeficiency among gay men, and 121 fatalities. The above photograph depicts a man\r\nwith Kaposi's Sarcoma, a rare cancer that afflicted many gay men in the early days\r\nof what would become known as AIDS.",
                 "id" : "2f1ef3ec-4038-4221-8a46-25f4a0230406",
                 "mediaSource" : "http://www.amfar.org/content.aspx?id=3598",
-                "mediaType" : "Picture",
+                "mediaType" : "DeepImage",
                 "parentExhibitId" : "e0f50dc4-6a67-47ae-adce-f59e348e39b1",
                 "title" : "Surprising increase in deaths among young men",
                 "uri" : "http://czbeta.blob.core.windows.net/images/67b92e39-7ee0-472c-96c4-f91392d52162_1981_man_with_aids.jpg"
@@ -688,7 +688,7 @@
                 "description" : "Between 1884 and 1924, somewhere near modern-day Kinshasa in West Central Africa, a hunter kills a chimpanzee. Some of the animal's blood enters the hunter's body, possibly through an open wound. The blood carries a virus harmless to the chimp but lethal to humans: HIV. The virus spreads as colonial cities sprout up, but the deaths are blamed on other causes.",
                 "id" : "d925039a-cf40-4cb4-b765-3234a2ec671f",
                 "mediaSource" : "http://www.webmd.com/hiv-aids/ss/slideshow-aids-retrospective",
-                "mediaType" : "Picture",
+                "mediaType" : "DeepImage",
                 "parentExhibitId" : "e0f50dc4-6a67-47ae-adce-f59e348e39b1",
                 "title" : "From monkeys to humans",
                 "uri" : "http://czbeta.blob.core.windows.net/images/70324732-94f0-4643-85cf-f2a8b58866c4_1981_photo_of_chimpanzee.jpg"
@@ -699,7 +699,7 @@
                 "description" : "There were many unofficial titles or descriptions of the cluster of diseases that were afflicting young gay men.  At one point the medical community considered the name GRID: which stood for Gay-related Immune Deficiency.  Another name was the 4-H syndrome, so named for the four groups of people who were mostly afflicted: homosexuals, hemophiliacs, heroine users, and Haitians.",
                 "id" : "10e13f6b-90f3-4dfc-85a7-6df50fa77009",
                 "mediaSource" : "http://www.amfar.org/content.aspx?id=3598",
-                "mediaType" : "Picture",
+                "mediaType" : "DeepImage",
                 "parentExhibitId" : "e0f50dc4-6a67-47ae-adce-f59e348e39b1",
                 "title" : "A disease not-yet named",
                 "uri" : "http://czbeta.blob.core.windows.net/images/87de8824-6052-4721-a62f-5bed615a646d_1981_RareCancer.jpg"
@@ -710,7 +710,7 @@
                 "description" : "By 2011, scholars had a better understanding about how the initial chimpanzee virus traveled from Central Africa to the West.  Two books reported on the historical evidence that mapped the virus' migration; both books argue that colonialist practices enabled the spread of the disease.\r\nHere a young man gets vaccinated against leprosy in Nigeria in the 1950s.",
                 "id" : "f0750205-f1c3-454f-8bee-daab35b4e22e",
                 "mediaSource" : "http://www.borders.com.au/book/the-origins-of-aids/24668311/, http://www.bookswim.com/title/Tinderbox_How_the_West_Sparked_the_AIDS_Epidemic_and_How_the_World_Can_Finally_Overcome_It-72250.html",
-                "mediaType" : "Picture",
+                "mediaType" : "DeepImage",
                 "parentExhibitId" : "e0f50dc4-6a67-47ae-adce-f59e348e39b1",
                 "title" : "How the initial infection traveled",
                 "uri" : "http://czbeta.blob.core.windows.net/images/4629ba32-6d0b-4d9c-978e-9769db6aa6a7_1981_colonialism-books.jpg"
@@ -740,7 +740,7 @@
                             "attribution" : "NAMES Foundation ",
                             "description" : "World AIDS Day — Emory University hosts 100 Quilt blocks, making it the largest Quilt display on any \r\ncollege campus.",
                             "id" : "e93e0b63-53dd-4810-b7ab-b89a045c5067",
-                            "mediaType" : "Picture",
+                            "mediaType" : "DeepImage",
                             "parentExhibitId" : "77d19a48-e186-4de2-af72-e3ff240ed563",
                             "title" : "Campus Display",
                             "uri" : "http://czbeta.blob.core.windows.net/images/b693ed0b-ea9d-44a7-9f39-bce34c1b2c00_2010.jpg"
@@ -755,7 +755,7 @@
                             "attribution" : "NAMES Foundation",
                             "description" : "In June and July, the Quilt marks its 25 anniversary on the National Mall by participating in the Smithsonian Institution’s 2012 Folklife Festival. The Festival program, titled “Creativity and Crisis: Unfolding The AIDS Memorial Quilt,” brings more than one million visitors face to face with The Quilt and includes an array of craft demonstrations, dance and musical performances, interactive discussions.\r\n\r\nThe Quilt is the premiere symbol of the AIDS pandemic and the largest piece of community art in the world – a living memorial to a generation lost to AIDS and our most potent HIV prevention education tool.",
                             "id" : "e19d6ad4-b8dc-426e-8e6b-998683b74117",
-                            "mediaType" : "Picture",
+                            "mediaType" : "DeepImage",
                             "parentExhibitId" : "8098ebbb-eea0-4df8-8326-b79e08effd12",
                             "title" : "The Quilt at the 2012 Folklife Festival",
                             "uri" : "http://czbeta.blob.core.windows.net/images/f8105783-5407-496d-a8bb-db790417d71e_2012-central-image.jpg"
@@ -765,7 +765,7 @@
                             "attribution" : "NAMES Foundation ",
                             "description" : "Twenty years ago a man came to the San Francisco workshop to drop off a new Quilt panel. This 3-foot-by-6-foot panel included no name, no photographs, no birth or death dates. Instead, this panel was a call to action, a quiet prayer, a stark reminder of what we are all working to achieve.We asked if we could hold on to this panel and only sewn into The AIDS Memorial Quilt when it was truly, the last one. With each Quilt display, each new panel, each scientific advancement, and each moment of recognition that AIDS is about all of us — we inch closer to realizing that goal.",
                             "id" : "459f3d6c-dd2a-40c2-9f65-3108c515f7ad",
-                            "mediaType" : "Picture",
+                            "mediaType" : "DeepImage",
                             "parentExhibitId" : "8098ebbb-eea0-4df8-8326-b79e08effd12",
                             "title" : "The Last One ",
                             "uri" : "http://czbeta.blob.core.windows.net/images/d89cf7ea-6d36-425b-be25-c24e437f029e_2012_last-one-panel.jpg"
@@ -792,7 +792,7 @@
                             "attribution" : "NAMES Foundation",
                             "description" : "In August, the NAMES Project partners with “Dreamgirls” Sheryl Lee Ralph to raise awareness and inspire the creation of new panels for members of the African American community. Ralph co-hosts a “Call My Name” panelmaking workshop on the Spelman College campus in Atlanta.",
                             "id" : "b9e96728-6df5-4caf-925d-ff18b86c0b7d",
-                            "mediaType" : "Picture",
+                            "mediaType" : "DeepImage",
                             "parentExhibitId" : "ef7f38d9-b48a-4121-a3c3-bec4e6f36216",
                             "title" : "Sheryl Lee Ralph Partners with the NAMES Project",
                             "uri" : "http://czbeta.blob.core.windows.net/images/e3dd5ce9-d1c2-4127-bd1d-316f105c7551_2011.jpg"
@@ -817,7 +817,7 @@
                             "attribution" : "NAMES Foundation ",
                             "description" : "The NAMES Project returns to the nation’s Capital for a third time with the entire AIDS Memorial Quilt, this time in the shadow of the Washington Monument. To reflect the global nature of the AIDS pandemic, this display was titled the “International Display.”.",
                             "id" : "973c053c-f747-4982-b695-eb294bf923be",
-                            "mediaType" : "Picture",
+                            "mediaType" : "DeepImage",
                             "parentExhibitId" : "1483f13f-612e-4922-8fe0-f24777156c78",
                             "title" : "Third Laying of the Quilt in Washington ",
                             "uri" : "http://czbeta.blob.core.windows.net/images/b0981003-b8d1-4fc2-998b-7c5cc9be7e28_1992.jpg"
@@ -832,7 +832,7 @@
                             "attribution" : "NAMES Foundation ",
                             "description" : "Seven hundred Quilt panels from 35 countries are displayed in San Francisco as part of events commemorating the 50th anniversary of the founding of the United Nations.\r\n\r\nIn San Francisco, the staff must sew 10,000 new panels into blocks for the upcoming national D.C. display. The staff sews 20 hours a day, doing 10-hour shifts. The volunteers that sew all night are called QUILT ZOMBIES. The staff also recruits volunteers from around the country to teach them how to bundle The Quilt, to edge, and grommet. \r\n\r\nAfter training in San Francisco, the volunteers return home to set-up sewing circles and The Quilt is literally stitched together in communities from coast to coast.“Toward the front, a woman at a sewing machine finished hemming a panel and folded it, carefully keeping the name face down. ’If I look at the names, I get sentimental,’ she said, ’So I don’t look, I just work.’”",
                             "id" : "726c2dc8-2dd5-4bda-931b-fdc362663817",
-                            "mediaType" : "Picture",
+                            "mediaType" : "DeepImage",
                             "parentExhibitId" : "4f27bd7a-cf0b-4410-b6f7-5b9a19d327af",
                             "title" : "Sewing the Quilt Together ",
                             "uri" : "http://czbeta.blob.core.windows.net/images/1648eee0-b89a-40b6-8adf-814529d85662_1994-central-image.jpg"
@@ -842,7 +842,7 @@
                             "attribution" : "NAMES Foundation",
                             "description" : "NAMES Project launches the National High School Quilt Program, a project that opens the doors to HIV prevention education in the school system.",
                             "id" : "0571159e-4320-479f-b1b2-b6f463196b01",
-                            "mediaType" : "Picture",
+                            "mediaType" : "DeepImage",
                             "parentExhibitId" : "4f27bd7a-cf0b-4410-b6f7-5b9a19d327af",
                             "title" : "National High School Quilt Program ",
                             "uri" : "http://czbeta.blob.core.windows.net/images/efcae040-9617-4c72-b8fe-a593c08f3849_1994-quilt-school-program.jpg"
@@ -852,7 +852,7 @@
                             "attribution" : "NAMES Foundation ",
                             "description" : "NAMES Project begins the National Interfaith Program to bring The Quilt to places of worship and to spiritual communities.",
                             "id" : "b7ebf71b-b32b-4ac0-94e9-8f3837299895",
-                            "mediaType" : "Picture",
+                            "mediaType" : "DeepImage",
                             "parentExhibitId" : "4f27bd7a-cf0b-4410-b6f7-5b9a19d327af",
                             "title" : "National Interfaith Program ",
                             "uri" : "http://czbeta.blob.core.windows.net/images/9240d07b-5dc5-42bf-8110-4363b0e20f6b_1994-Interfaith-program.jpg"
@@ -868,7 +868,7 @@
                             "attribution" : "NAMES Foundation ",
                             "description" : " President Clinton’s inaugural parade. Over 200 volunteers, including representatives of national AIDS organizations and Leanza Cornett, Miss America 1993, carry Quilt panels down Pennsylvania Avenue.\r\n\r\nForever remembered on The Quilt: Rudolph Nureyev, Michael Bennett, Robert Mapplethorpe, Freddie Mercury, Perry Ellis, Tony Perkins, Liberace, Keith Haring, Howard Ashman, Halston, Michael Foucault…",
                             "id" : "50dc0908-990b-4387-97f0-6a343a78d434",
-                            "mediaType" : "Picture",
+                            "mediaType" : "DeepImage",
                             "parentExhibitId" : "9b0937f5-1692-43a8-99ef-1d3fa5fb6780",
                             "title" : "The Quilt Featured in Clinton's Inaugural Parade ",
                             "uri" : "http://czbeta.blob.core.windows.net/images/879cdfaf-37ed-4540-a8ce-fb39eac69255_1993-central-image.jpg"
@@ -879,7 +879,7 @@
                             "description" : "Designers in the U.S. and England join forces to create a series of quilt panels remembering those lost by the fashion industry.",
                             "id" : "192274b3-fff8-4dff-ab15-8c54f1f427c9",
                             "mediaSource" : "http://www.stephenfried.com/gia/giabook_photos.html",
-                            "mediaType" : "Picture",
+                            "mediaType" : "DeepImage",
                             "parentExhibitId" : "9b0937f5-1692-43a8-99ef-1d3fa5fb6780",
                             "title" : "The Fashion Industry Remembered in the Quilt",
                             "uri" : "http://czbeta.blob.core.windows.net/images/8a3b8037-04ae-4d46-b2c2-46e223235e24_1993-fashion-industry-panel.jpg"
@@ -904,7 +904,7 @@
                             "attribution" : "NAMES Foundation",
                             "description" : "In October, the entire Quilt — 40,000 panels — is displayed on the National Mall in Washington, D.C. An estimated 1.2 million people visit. Covering the National Mall from the Washington Monument to the grounds of the U.S. Capital Building, The Quilt occupied an area equal to 24 football fields.\r\n\r\nPresident William J. Clinton attends the national Quilt display on the Mall, along with First Lady Hillary Rodham Clinton. He is the first U.S. President to visit a display of The AIDS Memorial Quilt.\r\n\r\n“I remember when Hillary and I walked on the Mall to see The Quilt. It was a personally emotional thing, seeing the love and devotion that those sections of The Quilt represented for all those people who died prematurely, and knowing that now, with medicine, they didn’t have to die so fast anymore, if we did the right things. It was a very emotional day.” — President William J. Clinton",
                             "id" : "6585390b-00d2-46b0-9563-74d4c39fdcab",
-                            "mediaType" : "Picture",
+                            "mediaType" : "DeepImage",
                             "parentExhibitId" : "cc06860c-f5ec-45b5-b3f9-0ea0a8682b38",
                             "title" : "Fourth Laying of the Quilt in Washington D.C. ",
                             "uri" : "http://czbeta.blob.core.windows.net/images/20e77ed0-8237-4675-9b96-390b9034d684_1996.jpg"
@@ -931,7 +931,7 @@
                             "description" : "In December, the NAMES Project orchestrates more than 300 World AIDS Day displays of the Quilt and brings more than a million Americans face to face with this American treasure.",
                             "id" : "61cb4405-77c9-4123-b941-87680402f793",
                             "mediaSource" : "http://projects.ajc.com/gallery/view/metro/news/today- pictures/111202weeksbestphotos/12.html",
-                            "mediaType" : "Picture",
+                            "mediaType" : "DeepImage",
                             "parentExhibitId" : "5ddeb1f0-741c-4bb6-9011-c6b9fcaa48c0",
                             "title" : "World AIDS Day Displays",
                             "uri" : "http://czbeta.blob.core.windows.net/images/c71a5727-265f-4b81-bc9e-6d655bd1fbaf_2002_central-image.jpg"
@@ -941,7 +941,7 @@
                             "attribution" : "NAMES Foundation ",
                             "description" : "“Call My Name” Panelmaking Program is launched in Atlanta to encourage communities of color to create new panels for loved ones lost to AIDS.",
                             "id" : "72d2ecff-c864-4e1a-acbe-b7f8695270ac",
-                            "mediaType" : "Picture",
+                            "mediaType" : "DeepImage",
                             "parentExhibitId" : "5ddeb1f0-741c-4bb6-9011-c6b9fcaa48c0",
                             "title" : "\"Call My Name\" ",
                             "uri" : "http://czbeta.blob.core.windows.net/images/d541b161-bc4a-445a-bab5-8ab5e64593bc_2002_Call-my-Name.jpg"
@@ -951,7 +951,7 @@
                             "attribution" : "NAMES Foundation ",
                             "description" : "The Quilt is featured alongside Billy Howard’s photography exhibit, “Epitaphs for the Living” in the Very Special Arts of Georgia Gallery.",
                             "id" : "468fe47f-6dd8-4444-bc05-e330bd080372",
-                            "mediaType" : "Picture",
+                            "mediaType" : "DeepImage",
                             "parentExhibitId" : "5ddeb1f0-741c-4bb6-9011-c6b9fcaa48c0",
                             "title" : "\"Epitaphs for the Living\" ",
                             "uri" : "http://czbeta.blob.core.windows.net/images/eec07909-90f6-46a8-a126-f48a9d3097de_2002_Epitaphs.jpg"
@@ -967,7 +967,7 @@
                             "attribution" : "NAMES Foundation ",
                             "description" : "The NAMES Project Foundation moves national headquarters to Atlanta. The cross-country move was made to shore up the Foundation’s finances and to be in a better position to address the changing face of HIV/AIDS.\r\n\r\nCivil Rights legend and Congressman John Lewis offers remarks at dedication ceremony.",
                             "id" : "84455d75-023a-4dfe-9684-2a6d3cf557d6",
-                            "mediaType" : "Picture",
+                            "mediaType" : "DeepImage",
                             "parentExhibitId" : "69a46f6d-e7f9-435e-8a69-3697c5fe2aa4",
                             "title" : "New Home for the NAMES Project",
                             "uri" : "http://czbeta.blob.core.windows.net/images/7bea88e4-2263-4db5-a8fe-0b68dfe8ca2e_2001.jpg"
@@ -983,7 +983,7 @@
                             "description" : "June 25, The NAMES Project returns to Washington, D.C. to display the 1000 newest Quilt blocks on The Ellipse",
                             "id" : "d611c5fe-5af0-4b0d-a0ee-430d8d3d4e9a",
                             "mediaSource" : "http://www.verbaljazz.com/2005/07/unfurling-aids-quilt-washington-dc.html ",
-                            "mediaType" : "Picture",
+                            "mediaType" : "DeepImage",
                             "parentExhibitId" : "b0225e94-e7ec-4da3-8912-a1a582e9a3bf",
                             "title" : "NAMES Project Returns to Washington, D.C.",
                             "uri" : "http://czbeta.blob.core.windows.net/images/245dcdf3-f4f1-4f53-8526-1ce1586005aa_2004.jpg"
@@ -998,7 +998,7 @@
                             "attribution" : "NAMES Foundation ",
                             "description" : "In December, MetroHealth System in Cleveland, Ohio presents “Art, Activism & AIDS” — a panel-making program that pairs panelmakers with art students and sewing specialists. Presented with a display of the Quilt.",
                             "id" : "e0e995e6-fa9e-4a51-8ef2-9581af82c792",
-                            "mediaType" : "Picture",
+                            "mediaType" : "DeepImage",
                             "parentExhibitId" : "bdf49947-580e-40e6-ad00-7a60ad79c468",
                             "title" : "Panelmakers Collaborate with Art Students",
                             "uri" : "http://czbeta.blob.core.windows.net/images/8dbf05c9-d504-4821-8b86-b3800700c6f8_2009.jpg"
@@ -1013,7 +1013,7 @@
                             "attribution" : "NAMES Foundation ",
                             "description" : "In October , The AIDS Memorial Quilt is declared an official American Treasure under the Save America’s Treasures Act — recognizing The Quilt as part of America’s priceless historic legacy and one that helps explain America’s past to future generations.\r\n\r\n“These treasures mark historic and continuing struggles to define, extend and uphold the nation’s founding ideals of freedom and equality.” \r\n— Brent D. Glass, former Director, National Museum of American History",
                             "id" : "d3b828d0-5436-4bf3-b216-b676ea696700",
-                            "mediaType" : "Picture",
+                            "mediaType" : "DeepImage",
                             "parentExhibitId" : "c8df96c5-f095-4b62-a634-087d16fafc84",
                             "title" : "The Quilt Is Declared an American Treasure ",
                             "uri" : "http://czbeta.blob.core.windows.net/images/6f243fae-14e0-4477-9857-a46b4ae3d506_2005_central-image.jpg"
@@ -1023,7 +1023,7 @@
                             "attribution" : "NAMES Foundation ",
                             "description" : "The panel for AIDS Activist Roger Lyon becomes part of an exhibition titled, “Smithsonian Treasures of American History” and is displayed alongside the Greensboro lunch counter where students protested racial segregation.",
                             "id" : "3a0a3639-0712-4d81-985a-81c15b3c7866",
-                            "mediaType" : "Picture",
+                            "mediaType" : "DeepImage",
                             "parentExhibitId" : "c8df96c5-f095-4b62-a634-087d16fafc84",
                             "title" : "Activist Roger Lyon's Panel Featured in an Exhibit ",
                             "uri" : "http://czbeta.blob.core.windows.net/images/60ea7e30-d78c-4f33-9cec-dab8672b54c9_2005-roger-lyon-panel.jpg"
@@ -1039,7 +1039,7 @@
                             "attribution" : "NAMES Foundation ",
                             "description" : "\r\nThe Quilt is featured at the opening ceremonies of the Gay Games in Chicago. \r\n\r\nFounder of the Gay Games, Dr. Tom Waddell, who was an Olympic athlete, is remembered with several panels including one on Block #687.\r\n\r\nThrough its evolution, The Quilt evolved as a powerful tool for social change. In 1987 when the first panel of The Quilt was constructed, public officials were debating mandatory testing and mandatory quarantines of infected citizens. Homophobic reaction to HIV/AIDS was rampant. First dubbed the “Gay Plague” and the disease of drug addicts, HIV/AIDS was a companion to prejudice and ignorance. The Quilt became a unifying force both for the gay community and for society. Quilt tours became a venue for peaceful demonstration; an opportunity for all people to stand together and honor those lost to AIDS and a means to support the gay community.",
                             "id" : "beedac14-f769-4277-9d0d-cae7ba7264a3",
-                            "mediaType" : "Picture",
+                            "mediaType" : "DeepImage",
                             "parentExhibitId" : "cd712aaf-4d86-4e1c-b14f-2c92bfafeafc",
                             "title" : "The Quilt and the LGBT Community ",
                             "uri" : "http://czbeta.blob.core.windows.net/images/4b2bbeeb-c739-4e52-af38-54acf9466c67_2006_central-image.jpg"
@@ -1050,7 +1050,7 @@
                             "description" : "In June and July , The Quilt is presented with the exhibition, “Beautiful Things: A Showcase of South African Craft” as part of the National Black Arts Festival in Atlanta.",
                             "id" : "d2218f40-e1cb-42e6-abcb-7a0f6078af5a",
                             "mediaSource" : "http://www.landesbergdesign.com/projects/nbaf.shtml ",
-                            "mediaType" : "Picture",
+                            "mediaType" : "DeepImage",
                             "parentExhibitId" : "cd712aaf-4d86-4e1c-b14f-2c92bfafeafc",
                             "title" : "The Quilt at the National Black Arts Festival ",
                             "uri" : "http://czbeta.blob.core.windows.net/images/2815a9f3-5b8c-4a22-9fbe-1e85d6061950_2006_NationalBlackArts.jpg"
@@ -1066,7 +1066,7 @@
                             "attribution" : "NAMES Foundation",
                             "description" : "In March, 100 new Quilt panels are begun in Atlanta in conjunction with the National Week of Prayer for the Healing of AIDS — seven panelmaking workshops are held in seven days. These workshops are a part of the “Call My Name” panelmaking program, that invites communities of color to create new panels to memorialize loved ones lost to AIDS.\r\n\r\nAs part of this commemoration, Rev. Raphael Warnock, the Senior Pastor of Historic Ebenezer Baptist Church in Atlanta, takes an HIV/AIDS test during the Sunday morning service to encourage members to do the same. \r\n\r\n“We don’t like to talk about these things in church. We’ve got to fight the unholy trinity of silence, shame and stigma.” As Reverend Warnock makes these remarks, he stands in front of four blocks of The Quilt.",
                             "id" : "04d2d3d6-f362-42ad-8b16-e4077bed7937",
-                            "mediaType" : "Picture",
+                            "mediaType" : "DeepImage",
                             "parentExhibitId" : "daeffba6-9f12-4a25-9314-2dd99374c48b",
                             "title" : "National Week of Prayer for the Healing of AIDS",
                             "uri" : "http://czbeta.blob.core.windows.net/images/3b211f1f-494f-4e47-a805-bb54afe69615_2008.jpg"
@@ -1081,7 +1081,7 @@
                             "attribution" : "NAMES Foundation ",
                             "description" : "From February to April, Andrea Bowers’ exhibition, “The Weight of Relevance” is on display at Secession in Vienna, Austria. The celebrated artist had previously spent more than a month with The NAMES Project for her Quilt based exhibition.",
                             "id" : "905c2eec-4e72-41e3-827e-7cd4e1c2a4e3",
-                            "mediaType" : "Picture",
+                            "mediaType" : "DeepImage",
                             "parentExhibitId" : "dbc66eb4-a5cc-442d-a8a9-189ef4991477",
                             "title" : "Artists Inspired by the Quilt ",
                             "uri" : "http://czbeta.blob.core.windows.net/images/1e9ea8e7-3501-467b-85e7-52d5c0ce5adf_2007_central-image.jpg"
@@ -1092,7 +1092,7 @@
                             "description" : "In December, More than 75 teens create HIV/AIDS awareness panels that are displayed with The Quilt at a World AIDS Day event at The Olivet Boys & Girls Club. Kevin Devera, leader of the club, dedicates a new panel in memory of his brother, Rick.",
                             "id" : "40f92f40-86f4-4c05-84b8-89e88affe0fe",
                             "mediaSource" : "http://www.educatingteens.org/",
-                            "mediaType" : "Picture",
+                            "mediaType" : "DeepImage",
                             "parentExhibitId" : "dbc66eb4-a5cc-442d-a8a9-189ef4991477",
                             "title" : "The Quilt and Teen AIDS Awareness",
                             "uri" : "http://czbeta.blob.core.windows.net/images/0e0d102a-d3f3-4a7f-9ecd-a8198951880a_2007_teen-AIDS-awareness.jpg"
@@ -1118,7 +1118,7 @@
                             "attribution" : "NAMES Foundation ",
                             "description" : "The Quilt now includes panels from every state and 28 countries. At the end of 1989, The Quilt is composed of 10,088 panels.",
                             "id" : "2aa7d934-fe8b-4cd3-905b-7cf21b7e7df1",
-                            "mediaType" : "Picture",
+                            "mediaType" : "DeepImage",
                             "parentExhibitId" : "55300e40-23af-4bcf-92b8-653b0fadcfe1",
                             "title" : "An International Memorial",
                             "uri" : "http://czbeta.blob.core.windows.net/images/7bc5d815-ad35-43b5-939b-38a4d8e57748_1989-central-image.jpg"
@@ -1128,7 +1128,7 @@
                             "attribution" : "NAMES Foundation",
                             "description" : "A second tour of North America brings The Quilt to 19 additional cities in the U.S. and Canada.",
                             "id" : "37706bd8-bdb3-4815-9649-3e562f8cfd6d",
-                            "mediaType" : "Picture",
+                            "mediaType" : "DeepImage",
                             "parentExhibitId" : "55300e40-23af-4bcf-92b8-653b0fadcfe1",
                             "title" : "Second American Tour ",
                             "uri" : "http://czbeta.blob.core.windows.net/images/2600d27b-47b3-42f8-a0c9-33cd507e719d_1989-second-american-tour.jpg"
@@ -1138,7 +1138,7 @@
                             "attribution" : "NAMES Foundation ",
                             "description" : "“Common Threads: Stories From The Quilt” wins the Academy Award as the best feature-length documentary film.",
                             "id" : "a023a7e5-40f0-4620-8dec-04044995a7e9",
-                            "mediaType" : "Picture",
+                            "mediaType" : "DeepImage",
                             "parentExhibitId" : "55300e40-23af-4bcf-92b8-653b0fadcfe1",
                             "title" : "The Quilt on Film ",
                             "uri" : "http://czbeta.blob.core.windows.net/images/96d5c002-718f-4017-9722-2d859b190abc_1989-Quilti-on-film.jpg"
@@ -1149,7 +1149,7 @@
                             "description" : "The AIDS Memorial Quilt is nominated for a Nobel Peace Prize.",
                             "id" : "31b59e9a-2241-4b28-8df3-7c6a2a4addff",
                             "mediaSource" : "Flickr ",
-                            "mediaType" : "Picture",
+                            "mediaType" : "DeepImage",
                             "parentExhibitId" : "55300e40-23af-4bcf-92b8-653b0fadcfe1",
                             "title" : "Quilt Nominated for Nobel Peace Prize",
                             "uri" : "http://czbeta.blob.core.windows.net/images/9430349d-35df-4794-937c-480acdf137ef_1989-Nobel-peace-prize.jpg"
@@ -1174,7 +1174,7 @@
                             "attribution" : "NAMES Foundation ",
                             "description" : "The NAMES Foundation project was established in 1987. Their mission is to preserve, care for, and use the AIDS Memorial Quilt to foster healing, heighten awareness, and inspire action in the struggle against HIV and AIDS.",
                             "id" : "cddc7c25-ee74-47d8-8410-c059f3dd2eef",
-                            "mediaType" : "Picture",
+                            "mediaType" : "DeepImage",
                             "parentExhibitId" : "56ba5e21-3366-4575-bd22-41b268b76fa7",
                             "title" : "The NAMES Foundation Project is Established ",
                             "uri" : "http://czbeta.blob.core.windows.net/images/8add4f3b-c913-42c7-bbd3-09bd5ed89f0a_Screen Shot 2012-07-11 at 11.42.34 AM.jpg"
@@ -1185,7 +1185,7 @@
                             "description" : "In June, the first Quilt Workshop opens at 2362 Market Street in San Francisco’s Castro Neighborhood. The panel for Reggie Hightower arrives from Atlanta. This is the first panel for someone outside San Francisco and it is the first indication that this Quilt is destined to be a national memorial.",
                             "id" : "b533a080-75c0-411d-b1d7-3581436c1430",
                             "mediaSource" : "http://www.burnaway.org/2011/10/aids-posters-and-memorial-quilt-panels-at-moda-are-multifaceted/",
-                            "mediaType" : "Picture",
+                            "mediaType" : "DeepImage",
                             "parentExhibitId" : "56ba5e21-3366-4575-bd22-41b268b76fa7",
                             "title" : "Beginning of a National Memorial ",
                             "uri" : "http://czbeta.blob.core.windows.net/images/7ebe4704-ccc3-4519-bb9d-ef9c4a243c18_1987-ReggieHightower-panel.jpg"
@@ -1195,7 +1195,7 @@
                             "attribution" : "NAMES Foundation",
                             "description" : "“The Quilt is a masterpiece. It is a rare and intense experience of what it means to be human.” \r\n\r\n— Dame Elizabeth Taylor",
                             "id" : "b3a1622a-a0f3-488f-a197-375cf0a5e0ea",
-                            "mediaType" : "Picture",
+                            "mediaType" : "DeepImage",
                             "parentExhibitId" : "56ba5e21-3366-4575-bd22-41b268b76fa7",
                             "title" : "Elizabeth Taylor: Actress and International AIDS Activist ",
                             "uri" : "http://czbeta.blob.core.windows.net/images/4015792c-4eef-46b3-863c-a90746183b9b_1987_Elizabeth-Taylor-quote.jpg"
@@ -1206,7 +1206,7 @@
                             "description" : "“We thought we’d close the doors after the first year. I even wrote my name and address on the first two panels I made because I wanted them back.” \r\n\r\n– Gert McMullin",
                             "id" : "bf6a2c12-b56d-43da-b566-29db866a000e",
                             "mediaSource" : "http://allensullivan.com/",
-                            "mediaType" : "Picture",
+                            "mediaType" : "DeepImage",
                             "parentExhibitId" : "56ba5e21-3366-4575-bd22-41b268b76fa7",
                             "title" : "Gert McMullin: Quilt Production Manager and 25 Year Quilt Veteran",
                             "uri" : "http://czbeta.blob.core.windows.net/images/aeef2bdc-d942-42ed-9cf4-c2048de249aa_1987_GertMcMullin.jpg"
@@ -1217,7 +1217,7 @@
                             "description" : "In August, the first Quilt panel arrives for Rock Hudson. In a matter of days, Rock Hudson’s panel, along with 40 others, are featured in a 40-foot high front window of Neiman Marcus in San Francisco. \r\n\r\nRock Hudson is remembered with 16 Quilt panels including one on Block #1009, created by Jason Derer, with the help of his Aunt Doris Day.",
                             "id" : "538d412d-9590-4371-9e89-6360fe847b47",
                             "mediaSource" : "http://173.165.165.36:591/FMRes/FMPro?-db=search%20the%20quilt.fp5&- format=ztablevw.htm&-lay=large%20display&-sortfield=block%20number&- skip=36&-findall=",
-                            "mediaType" : "Picture",
+                            "mediaType" : "DeepImage",
                             "parentExhibitId" : "56ba5e21-3366-4575-bd22-41b268b76fa7",
                             "title" : "Rock Hudson's Panel Displayed in San Francisco",
                             "uri" : "http://czbeta.blob.core.windows.net/images/13ada36b-9cd9-4ee1-a357-4b97675d623b_1987_Rock_Hudson.jpg"
@@ -1227,7 +1227,7 @@
                             "attribution" : "NAMES Foundation ",
                             "description" : "On June 28, to prepare for the first display of The Quilt, volunteers decide to stitch eight individual panels together to create the first block of The Quilt. Those first 44 Quilt panels are sewn into five blocks, which are hung from the Mayor’s Balcony in San Francisco as part of Gay Pride. The four remaining single panels are also displayed as part of an informational table. ",
                             "id" : "32fe2202-ae94-428a-b941-32fc5dd883ef",
-                            "mediaType" : "Picture",
+                            "mediaType" : "DeepImage",
                             "parentExhibitId" : "56ba5e21-3366-4575-bd22-41b268b76fa7",
                             "title" : "Panels Sewn into Blocks ",
                             "uri" : "http://czbeta.blob.core.windows.net/images/a495ecc1-2c00-4925-a3c2-b67cf333747a_1987-panels-sewn-into-blocks.jpg"
@@ -1237,7 +1237,7 @@
                             "attribution" : "NAMES Foundation ",
                             "description" : "Cleve Jones and Joseph Durant create the first panels for The AIDS Memorial Quilt. The panels measure 3 feet by six feet, roughly the size of a human grave.\r\n\r\nOn October 11, the first National Display of The Quilt is presented on the Mall in Washington, D.C. and includes 1,920 panels. \r\n\r\nThis display transforms statistics into souls and ignites a national conversation on HIV/AIDS.",
                             "id" : "52a732e3-9d73-4121-bd38-c3fcdbc856da",
-                            "mediaType" : "Picture",
+                            "mediaType" : "DeepImage",
                             "parentExhibitId" : "56ba5e21-3366-4575-bd22-41b268b76fa7",
                             "title" : "From Statistics to Souls ",
                             "uri" : "http://czbeta.blob.core.windows.net/images/3dd1f12d-e308-45e0-a442-a8bcc5057811_1987_Central-image.jpg"
@@ -1253,7 +1253,7 @@
                             "attribution" : "NAMES Foundation ",
                             "description" : "On November 23, as crowds gathered for the annual candlelight vigil in memory of assassinated City Supervisory Harvey Milk and San Francisco Mayor Edward Muscone, San Franciscans are urged to write the name of a loved one lost to AIDS on a poster board and carry it with them as they marched. Many are too scared but others write the names: Mark, Roger, David … Later that night, those few dozen poster boards are plastered on the front of the Old Federal Building and become the inspiration for The AIDS Memorial Quilt.",
                             "id" : "1f27ce29-7858-4d3a-b422-e9e1ec0c472b",
-                            "mediaType" : "Picture",
+                            "mediaType" : "DeepImage",
                             "parentExhibitId" : "915120f4-cfa6-43e3-9e6e-4989a29a8586",
                             "title" : "Candlelight Vigil for Harvey Milk",
                             "uri" : "http://czbeta.blob.core.windows.net/images/be925626-9910-437c-a149-8d6f247cd9fd_1985.jpg"
@@ -1277,7 +1277,7 @@
                             "attribution" : "NAMES Foundation ",
                             "description" : "In October, a second national display of The Quilt is presented on the Ellipse in Washington, D.C. 8,288 panels on display.",
                             "id" : "cdb67856-6ca2-4e30-8c05-e94063bcc013",
-                            "mediaType" : "Picture",
+                            "mediaType" : "DeepImage",
                             "parentExhibitId" : "f110080d-3ea2-4152-a31b-d5e7a758fc6d",
                             "title" : "Panels on Display in Washington ",
                             "uri" : "http://czbeta.blob.core.windows.net/images/c5daa4b1-feb3-4172-b3a7-35f51d46c4fa_1988-panels-on-display-in-washington.jpg"
@@ -1287,7 +1287,7 @@
                             "attribution" : "NAMES Foundation ",
                             "description" : "From April to July, seven volunteers load The Quilt, all 3500 panels, into a 30-foot white truck the group names Stella. For the next four months, they zig-zag across the country, displaying The Quilt in communities where volunteers step forward and free venues can be secured. Individuals who follow The Quilt from city to city are nicknamed Thread Heads. The tour raises $500,000 for hundreds of AIDS service organizations. More than 9,000 volunteers across the US help the seven-person traveling crew move and display The Quilt. \r\n\r\nIn the summer, Dr. Jonathan Mann, founding director of World Health Organization’s Global Program on AIDS, orchestrates a European tour of The Quilt to unite the world’s response to the pandemic and to establish a worldwide ritual to be called World AIDS Day. ",
                             "id" : "1b30c484-552b-41d3-99b3-6b1943fc10c1",
-                            "mediaType" : "Picture",
+                            "mediaType" : "DeepImage",
                             "parentExhibitId" : "f110080d-3ea2-4152-a31b-d5e7a758fc6d",
                             "title" : "The Quilt Tours the U.S. and Europe",
                             "uri" : "http://czbeta.blob.core.windows.net/images/4f8cf309-9869-4524-95b9-4b32de0bcaa2_1988-central-image.jpg"

--- a/Source/Chronozoom.UI/cz.js
+++ b/Source/Chronozoom.UI/cz.js
@@ -1873,6 +1873,8 @@ var CZ;
                     var mediaID = id + "__media__";
                     var imageElem = null;
                     if(this.contentItem.mediaType.toLowerCase() === 'image' || this.contentItem.mediaType.toLowerCase() === 'picture') {
+                        imageElem = VCContent.addImage(container, layerid, mediaID, vx + leftOffset, mediaTop, contentWidth, mediaHeight, this.contentItem.uri);
+                    } else if(this.contentItem.mediaType.toLowerCase() === 'deepimage') {
                         imageElem = VCContent.addSeadragonImage(container, layerid, mediaID, vx + leftOffset, mediaTop, contentWidth, mediaHeight, CZ.Settings.mediaContentElementZIndex, this.contentItem.uri);
                     } else if(this.contentItem.mediaType.toLowerCase() === 'video') {
                         VCContent.addVideo(container, layerid, mediaID, this.contentItem.uri, vx + leftOffset, mediaTop, contentWidth, mediaHeight, CZ.Settings.mediaContentElementZIndex);
@@ -10943,7 +10945,7 @@ var CZ;
                 var _this = this;
                 var newContentItem = {
                     title: this.titleInput.val() || "",
-                    uri: decodeURIComponent(this.mediaInput.val()) || "",
+                    uri: this.mediaInput.val() || "",
                     mediaSource: this.mediaSourceInput.val() || "",
                     mediaType: this.mediaTypeInput.val() || "",
                     attribution: this.attributionInput.val() || "",

--- a/Source/Chronozoom.UI/scripts/cz.js
+++ b/Source/Chronozoom.UI/scripts/cz.js
@@ -70,7 +70,7 @@ var CZ;
             
         ];
         function InitializeToursUI(profile, forms) {
-            var allowEditing = true;
+            var allowEditing = IsFeatureEnabled(_featureMap, "Authoring") && (profile && profile != "" && profile.DisplayName === CZ.Service.superCollectionName);
             var onToursInitialized = function () {
                 CZ.Tours.initializeToursUI();
                 $("#tours_index").click(function () {

--- a/Source/Chronozoom.UI/scripts/vccontent.js
+++ b/Source/Chronozoom.UI/scripts/vccontent.js
@@ -1278,6 +1278,8 @@ var CZ;
                     var mediaID = id + "__media__";
                     var imageElem = null;
                     if(this.contentItem.mediaType.toLowerCase() === 'image' || this.contentItem.mediaType.toLowerCase() === 'picture') {
+                        imageElem = VCContent.addImage(container, layerid, mediaID, vx + leftOffset, mediaTop, contentWidth, mediaHeight, this.contentItem.uri);
+                    } else if(this.contentItem.mediaType.toLowerCase() === 'deepimage') {
                         imageElem = VCContent.addSeadragonImage(container, layerid, mediaID, vx + leftOffset, mediaTop, contentWidth, mediaHeight, CZ.Settings.mediaContentElementZIndex, this.contentItem.uri);
                     } else if(this.contentItem.mediaType.toLowerCase() === 'video') {
                         VCContent.addVideo(container, layerid, mediaID, this.contentItem.uri, vx + leftOffset, mediaTop, contentWidth, mediaHeight, CZ.Settings.mediaContentElementZIndex);

--- a/Source/Chronozoom.UI/scripts/vccontent.ts
+++ b/Source/Chronozoom.UI/scripts/vccontent.ts
@@ -1876,9 +1876,11 @@ module CZ {
                     var mediaID = id + "__media__";
                     var imageElem = null;
                     if (this.contentItem.mediaType.toLowerCase() === 'image' || this.contentItem.mediaType.toLowerCase() === 'picture') {
-                        imageElem = addSeadragonImage(container, layerid, mediaID, vx + leftOffset, mediaTop, contentWidth, mediaHeight, CZ.Settings.mediaContentElementZIndex, this.contentItem.uri);
+                        imageElem = addImage(container, layerid, mediaID, vx + leftOffset, mediaTop, contentWidth, mediaHeight, this.contentItem.uri);
                     }
-                    else if (this.contentItem.mediaType.toLowerCase() === 'video') {
+                    else if (this.contentItem.mediaType.toLowerCase() === 'deepimage') {
+                        imageElem = addSeadragonImage(container, layerid, mediaID, vx + leftOffset, mediaTop, contentWidth, mediaHeight, CZ.Settings.mediaContentElementZIndex, this.contentItem.uri);
+                    } else if (this.contentItem.mediaType.toLowerCase() === 'video') {
                         addVideo(container, layerid, mediaID, this.contentItem.uri, vx + leftOffset, mediaTop, contentWidth, mediaHeight, CZ.Settings.mediaContentElementZIndex);
                     }
                     else if (this.contentItem.mediaType.toLowerCase() === 'audio') {

--- a/Source/Chronozoom.UI/ui/auth-edit-contentitem-form.js
+++ b/Source/Chronozoom.UI/ui/auth-edit-contentitem-form.js
@@ -71,7 +71,7 @@ var CZ;
                 var _this = this;
                 var newContentItem = {
                     title: this.titleInput.val() || "",
-                    uri: decodeURIComponent(this.mediaInput.val()) || "",
+                    uri: this.mediaInput.val() || "",
                     mediaSource: this.mediaSourceInput.val() || "",
                     mediaType: this.mediaTypeInput.val() || "",
                     attribution: this.attributionInput.val() || "",

--- a/Source/Chronozoom.UI/ui/auth-edit-contentitem-form.ts
+++ b/Source/Chronozoom.UI/ui/auth-edit-contentitem-form.ts
@@ -109,7 +109,7 @@ module CZ {
             private onSave() {
                 var newContentItem = {
                     title: this.titleInput.val() || "",
-                    uri: decodeURIComponent(this.mediaInput.val()) || "",
+                    uri: this.mediaInput.val() || "",
                     mediaSource: this.mediaSourceInput.val() || "",
                     mediaType: this.mediaTypeInput.val() || "",
                     attribution: this.attributionInput.val() || "",


### PR DESCRIPTION
Code Review: http://mrccodereview.cloudapp.net/ui#review:id=1267

This was discussed with Peter/Roman: SeaDragon images are causing more trouble than benefit due to new authoring feature:
a) They take too long to load
b) Encoded URLs maliciously crafted can show users unexpected images

Therefore, we are removing SeaDragon images except for the AIDS-Quilt timeline.
