### PR TITLE
Bug #681: IE does not render page in HTML5 strict mode

### DIFF
--- a/Source/Chronozoom.UI/cz.html
+++ b/Source/Chronozoom.UI/cz.html
@@ -2,7 +2,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
     <meta http-equiv="Pragma" content="no-cache" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="Description" content="ChronoZoom is an open-source community project dedicated to visualizing the history of everything." />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <script type="text/javascript" id="constants"></script>

--- a/Source/Chronozoom.UI/default.ashx.cs
+++ b/Source/Chronozoom.UI/default.ashx.cs
@@ -135,6 +135,9 @@ namespace Chronozoom.UI
                     XmlReader xmlReader = new XmlTextReader(streamReader);
                     XDocument pageRoot = XDocument.Load(xmlReader);
 
+                    // Remove DOCTYPE extra []
+                    pageRoot.DocumentType.InternalSubset = null;
+
                     XNamespace ns = "http://www.w3.org/1999/xhtml";
                     XmlNamespaceManager xmlNamespaceManager = new XmlNamespaceManager(xmlReader.NameTable);
                     xmlNamespaceManager.AddNamespace("xhtml", ns.ToString());
@@ -196,11 +199,6 @@ namespace Chronozoom.UI
 
                 metaDescription.SetAttributeValue(contentAttribute, pageInformation.Description);
             }
-
-            XElement metaIECompatibile = pageRoot.XPathSelectElement("/xhtml:html/xhtml:head/xhtml:meta[@http-equiv='X-UA-Compatible']", xmlNamespaceManager);
-            XName contentIEAttribute = "content";
-
-            metaIECompatibile.SetAttributeValue(contentIEAttribute, "IE=edge");
 
             XElement lastMetaTag = pageRoot.XPathSelectElement("/xhtml:html/xhtml:head/xhtml:meta[@name='viewport']", xmlNamespaceManager);
             int imageCount = 0;


### PR DESCRIPTION
Code Review: http://mrccodereview.cloudapp.net/ui#review:id=1273

Remove ad-hoc X-UA-Compatible IE-Edge meta tag and instead write <!DOCTYPE html> correctly.
