### PR TITLE
Bug #693: Music content item is not played

### DIFF
--- a/Source/Chronozoom.UI/ui/auth-edit-contentitem-form.html
+++ b/Source/Chronozoom.UI/ui/auth-edit-contentitem-form.html
@@ -33,7 +33,6 @@
         <option value ="image"> Image </option>
         <option value ="pdf"> PDF </option>
         <option value ="video"> Video </option>
-        <option value ="audio"> Audio </option>
     </select>
 
     <br />


### PR DESCRIPTION
Code Review: http://mrccodereview.cloudapp.net/ui#review:id=1276

a) First, beta content never used audio files (I searched for OGG/MP3/WAV under http://beta.chronozoom.com/chronozoom.svc/get?).
b) Audio files render incorrectly, this is being tested too close to shipping.
c) Some browsers support OGG some others support MP3; therefore, some exhibits will look broken for some users/browsers.
