### PR TITLE
HotFix: Deployment blocked caused by missing image reference

### DIFF
--- a/Source/Chronozoom.UI/Chronozoom.UI.csproj
+++ b/Source/Chronozoom.UI/Chronozoom.UI.csproj
@@ -247,7 +247,7 @@
     <Content Include="images\edit-icon.png" />
     <Content Include="images\profile-icon.png" />
     <Content Include="images\search-icon.png" />
-    <Content Include="images\timseries-icon.png" />
+    <Content Include="images\timeseries-icon.png" />
     <Content Include="images\tour-icon.png" />
     <Content Include="images\view-icon.png" />
     <Content Include="images\edit.svg" />


### PR DESCRIPTION
Renamed tim-series-icon.png into time-series-icon.png but forgot to rename reference in CSPROJ which is used during deployment.
