### PR TITLE
Convert the relative content item 'order' into absolute position within exhibit.

### DIFF
--- a/Source/Chronozoom.UI/cz.js
+++ b/Source/Chronozoom.UI/cz.js
@@ -1994,8 +1994,23 @@ var CZ;
             this.title = infodotDescription.title;
             this.opacity = typeof infodotDescription.opacity !== 'undefined' ? infodotDescription.opacity : 1;
             contentItems.sort(function (a, b) {
-                return a.order - b.order;
+                if(typeof a.order !== 'undefined' && typeof b.order === 'undefined') {
+                    return -1;
+                } else if(typeof a.order === 'undefined' && typeof b.order !== 'undefined') {
+                    return 1;
+                } else if(typeof a.order === 'undefined' && typeof b.order === 'undefined') {
+                    return 0;
+                } else if(a.order < b.order) {
+                    return -1;
+                } else if(a.order > b.order) {
+                    return 1;
+                } else {
+                    return 0;
+                }
             });
+            for(var i = 0; i < contentItems.length; i++) {
+                contentItems[i].order = i;
+            }
             var vyc = this.newY + radv;
             var innerRad = radv - CZ.Settings.infoDotHoveredBorderWidth * radv;
             this.outerRad = radv;
@@ -2317,7 +2332,7 @@ var CZ;
             var xr = xc + rad * (_xrc - _lw / 2);
             var yb = yc + rad * (_ybc - _lh / 2);
             var vcitems = [];
-            for(var i = 0, len = Math.min(10, n); i < len; i++) {
+            for(var i = 0, len = Math.min(CZ.Settings.infodotMaxContentItemsCount, n); i < len; i++) {
                 var ci = contentItems[i];
                 if(i === 0) {
                     vcitems.push(new ContentItem(vc, layerid, ci.id, -_wc / 2 * rad + xc, -_hc / 2 * rad + yc, _wc * rad, _hc * rad, ci));

--- a/Source/Chronozoom.UI/scripts/settings.ts
+++ b/Source/Chronozoom.UI/scripts/settings.ts
@@ -52,7 +52,7 @@
         export var infoDotHoveredBorderColor = 'white'; // color of infdot's circle border when mouse cursor is over it
         export var infoDotFillColor = 'rgb(92,92,92)'; // color of infdot's circle border
         export var infoDotTinyContentImageUri = '/images/tinyContent.png';
-        export var infodotMaxContentItemsCount = 10;
+        export var infodotMaxContentItemsCount = 10; // range [1, 10]
 
         export var mediaContentElementZIndex = 100;
         export var contentItemDescriptionNumberOfLines = 10;

--- a/Source/Chronozoom.UI/scripts/vccontent.js
+++ b/Source/Chronozoom.UI/scripts/vccontent.js
@@ -1399,8 +1399,23 @@ var CZ;
             this.title = infodotDescription.title;
             this.opacity = typeof infodotDescription.opacity !== 'undefined' ? infodotDescription.opacity : 1;
             contentItems.sort(function (a, b) {
-                return a.order - b.order;
+                if(typeof a.order !== 'undefined' && typeof b.order === 'undefined') {
+                    return -1;
+                } else if(typeof a.order === 'undefined' && typeof b.order !== 'undefined') {
+                    return 1;
+                } else if(typeof a.order === 'undefined' && typeof b.order === 'undefined') {
+                    return 0;
+                } else if(a.order < b.order) {
+                    return -1;
+                } else if(a.order > b.order) {
+                    return 1;
+                } else {
+                    return 0;
+                }
             });
+            for(var i = 0; i < contentItems.length; i++) {
+                contentItems[i].order = i;
+            }
             var vyc = this.newY + radv;
             var innerRad = radv - CZ.Settings.infoDotHoveredBorderWidth * radv;
             this.outerRad = radv;
@@ -1722,7 +1737,7 @@ var CZ;
             var xr = xc + rad * (_xrc - _lw / 2);
             var yb = yc + rad * (_ybc - _lh / 2);
             var vcitems = [];
-            for(var i = 0, len = Math.min(10, n); i < len; i++) {
+            for(var i = 0, len = Math.min(CZ.Settings.infodotMaxContentItemsCount, n); i < len; i++) {
                 var ci = contentItems[i];
                 if(i === 0) {
                     vcitems.push(new ContentItem(vc, layerid, ci.id, -_wc / 2 * rad + xc, -_hc / 2 * rad + yc, _wc * rad, _hc * rad, ci));

--- a/Source/Chronozoom.UI/scripts/vccontent.ts
+++ b/Source/Chronozoom.UI/scripts/vccontent.ts
@@ -2031,8 +2031,18 @@ module CZ {
             this.opacity = typeof infodotDescription.opacity !== 'undefined' ? infodotDescription.opacity : 1;
 
             contentItems.sort(function (a, b) {
-                return a.order - b.order;
+                if (typeof a.order !== 'undefined' && typeof b.order === 'undefined') return -1;
+                else if (typeof a.order === 'undefined' && typeof b.order !== 'undefined') return 1;
+                else if (typeof a.order === 'undefined' && typeof b.order === 'undefined') return 0;
+                else if (a.order < b.order) return -1;
+                else if (a.order > b.order) return 1;
+                else return 0;
             });
+
+            // convert relative content item order to absolute position
+            for (var i = 0; i < contentItems.length; i++) {
+                contentItems[i].order = i;
+            }
 
             var vyc = this.newY + radv;
             var innerRad = radv - CZ.Settings.infoDotHoveredBorderWidth * radv;
@@ -2430,7 +2440,7 @@ module CZ {
             // build content items
             var vcitems = [];
 
-            for (var i = 0, len = Math.min(10, n); i < len; i++) {
+            for (var i = 0, len = Math.min(CZ.Settings.infodotMaxContentItemsCount, n); i < len; i++) {
                 var ci = contentItems[i];
                 if (i === 0) { // center
                     vcitems.push(new ContentItem(vc, layerid, ci.id, -_wc / 2 * rad + xc, -_hc / 2 * rad + yc, _wc * rad, _hc * rad, ci));


### PR DESCRIPTION
Some one updated the server. Now some ci don't has order field, which breaks authoring.
This fix explicitly adds the 'order' field if its missing.
