### PR TITLE
HotFix: New users get error page after signing in

### DIFF
--- a/Source/Chronozoom.UI/ACS/Controllers/AccountController.cs
+++ b/Source/Chronozoom.UI/ACS/Controllers/AccountController.cs
@@ -52,25 +52,29 @@ namespace Chronozoom.Api.Controllers
             {
                 var user = (Microsoft.IdentityModel.Claims.IClaimsIdentity)HttpContext.User.Identity;
 
-                string nameIdentifier = "";
-                string identityProvider = "";
-
-                foreach (var item in user.Claims)
+                if (user != null)
                 {
-                    if (item.ClaimType.EndsWith("nameidentifier"))
-                    {
-                        nameIdentifier = item.Value;
-                    }
-                    else if (item.ClaimType.EndsWith("identityprovider"))
-                    {
-                        identityProvider = item.Value;
-                    }
-                }
+                    string nameIdentifier = "";
+                    string identityProvider = "";
 
-                using (Storage storage = new Storage())
-                {
-                    Entities.User storedUser = storage.Users.FirstOrDefault(candidate => candidate.IdentityProvider == identityProvider && candidate.NameIdentifier == nameIdentifier);
-                    return Redirect("/" + storedUser.DisplayName);
+                    foreach (var item in user.Claims)
+                    {
+                        if (item.ClaimType.EndsWith("nameidentifier"))
+                        {
+                            nameIdentifier = item.Value;
+                        }
+                        else if (item.ClaimType.EndsWith("identityprovider"))
+                        {
+                            identityProvider = item.Value;
+                        }
+                    }
+
+                    using (Storage storage = new Storage())
+                    {
+                        Entities.User storedUser = storage.Users.FirstOrDefault(candidate => candidate.IdentityProvider == identityProvider && candidate.NameIdentifier == nameIdentifier);
+                        if (storedUser != null)
+                            return Redirect("/" + storedUser.DisplayName);
+                    }
                 }
             }
 


### PR DESCRIPTION
The problem is that new code to redirect users to personal collection assumes that the personal collection exists; however, this is not true the first time a user logs in.
