### PR TITLE
Bug #710: Logout as yahoo user - incorrect behavior

### DIFF
--- a/Source/Chronozoom.UI/pages/logoff.aspx
+++ b/Source/Chronozoom.UI/pages/logoff.aspx
@@ -7,8 +7,22 @@
     <title>Logging Out - ChronoZoom</title>
 </head>
 <body>
-    <iframe src="<% Response.Write(Chronozoom.UI.LogOff.LogOffUrl().ToString()); %>" seamless="seamless" style="border: 0px none transparent;" onload="window.location = '/';">
+    <iframe width="1" height="1" src="<% Response.Write(Chronozoom.UI.LogOff.LogOffUrl().ToString()); %>" seamless="seamless" style="border: 0px none transparent;" onload="window.location = '/';">
 
     </iframe>
+
+    <% if (Chronozoom.UI.LogOff.GetIdentityProvider() == "Yahoo!") { %>
+    <script>
+        function CheckLoadStatusAndWait() {
+            if (document.readyState !== "complete") {
+                setTimeout("CheckLoadStatusAndWait();", 500);
+            } else {
+                window.location = "/";
+            }
+        }
+
+        CheckLoadStatusAndWait();
+    </script> 
+    <% } %>
 </body>
 </html>

--- a/Source/Chronozoom.UI/pages/logoff.aspx.cs
+++ b/Source/Chronozoom.UI/pages/logoff.aspx.cs
@@ -49,7 +49,8 @@ namespace Chronozoom.UI
             return logOffUrl;
         }
 
-        private static string GetIdentityProvider()
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
+        public static string GetIdentityProvider()
         {
             Microsoft.IdentityModel.Claims.ClaimsIdentity claimsIdentity = System.Web.HttpContext.Current.User.Identity as Microsoft.IdentityModel.Claims.ClaimsIdentity;
 


### PR DESCRIPTION
Code Review: http://mrccodereview.cloudapp.net/ui#review:id=1286

Yahoo logoff page loads empty inside an iframe which makes the onload event for the iframe not fire. Instead, for Yahoo, use the onload event for the whole page.
