### PR TITLE
 #621 API: Code in PutCollectionName API does not validate that user owns supercollection

### DIFF
--- a/Source/Chronozoom.UI/api/Chronozoom.svc.cs
+++ b/Source/Chronozoom.UI/api/Chronozoom.svc.cs
@@ -765,7 +765,9 @@ namespace Chronozoom.UI
                     return Guid.Empty;
                 }
 
-                if (user == null)
+                Guid superCollectionId = CollectionIdFromText(superCollectionName);
+                SuperCollection superCollection = RetrieveSuperCollection(storage, superCollectionId);
+                if (user == null || superCollection.User != user)
                 {
                     // No ACS so treat as an anonymous user who cannot add or modify a collection.
                     SetStatusCode(HttpStatusCode.Unauthorized, ErrorDescription.UnauthorizedUser);


### PR DESCRIPTION
#621

Added check to make sure supercollection user is the same as user requesting to add a content item to supercollection.
http://mrccodereview.cloudapp.net/ui#review:id=1296
