### PR TITLE
Updated Dev_guide to include Chutzpah for VS

### DIFF
--- a/Doc/ChronoZoom_Developer_Guide.md
+++ b/Doc/ChronoZoom_Developer_Guide.md
@@ -32,6 +32,7 @@ If you are new to GitHub, we recommend reading [Learning to use GitHub for Chron
 - [Visual Studio 2012 Ultimate](http://www.microsoft.com/visualstudio/eng/products/visual-studio-overview) or [Visual Studio Express for Web](http://www.microsoft.com/visualstudio/eng/products/visual-studio-express-for-web)
 - [Visual Studio 2012.2 CTP 3](http://www.microsoft.com/en-us/download/details.aspx?id=36833)
 - [Visual Studio Tools for Git](http://visualstudiogallery.msdn.microsoft.com/abafc7d6-dcaa-40f4-8a5e-d6724bdb980c)
+- [Chutzpah Test Adapter for Visual Studio 2012] (http://visualstudiogallery.msdn.microsoft.com/f8741f04-bae4-4900-81c7-7c9bfb9ed1fe)
 - [Git for Windows](http://code.google.com/p/msysgit/downloads/list?q=full+installer+official+git)
  - Be sure to select 'Run Git from the Windows Command Prompt' during installation.
 - Install Windows Identity Foundation (Control Panel, Programs and Features, Turn Windows Feature on or off, Turn on Windows Identity Foundation 3.5)


### PR DESCRIPTION
Edited Chronozoom_Developer_Guide.md to include a link to Chutzpah Test Adapter for Visual Studio 2012 so that all Unit Tests processes when the solution is opened.
