### PR TITLE
Bug #746: Error is we extend the timeline to the borders of the parent

### DIFF
--- a/Source/Chronozoom.UI.Unittests/Scripts/Specs/authoringSpec.js
+++ b/Source/Chronozoom.UI.Unittests/Scripts/Specs/authoringSpec.js
@@ -1,4 +1,5 @@
-﻿/// <reference path="../../../Chronozoom.UI/scripts/authoring.js" />
+﻿/// <reference path="../../../Chronozoom.UI/scripts/settings.js" />
+/// <reference path="../../../Chronozoom.UI/scripts/authoring.js" />
 /// <reference path="../../../Chronozoom.UI/scripts/dates.js" />
 
 describe("CZ.Authoring part", function () {

--- a/Source/Chronozoom.UI.Unittests/Scripts/Specs/datesSpec.js
+++ b/Source/Chronozoom.UI.Unittests/Scripts/Specs/datesSpec.js
@@ -1,4 +1,5 @@
-﻿/// <reference path="../../../Chronozoom.UI/scripts/dates.js" />
+﻿/// <reference path="../../../Chronozoom.UI/scripts/settings.js" />
+/// <reference path="../../../Chronozoom.UI/scripts/dates.js" />
 
 describe("convertYearToCoordinate method should return", function () {
 
@@ -253,6 +254,12 @@ describe("isLeapYear() method", function () {
     });
 });
 
+describe("getCoordinateFromYMD() roundtrips with getYMDFromCoordinate()", function () {
+    var coordinate = CZ.Dates.getCoordinateFromYMD(500, 1, 1);
+    var date = CZ.Dates.getYMDFromCoordinate(coordinate);
+    expect(500).toEqual(date.year);
+});
+
 function convertCoordinateToYear(coordinate) {
     return CZ.Dates.convertCoordinateToYear(coordinate);
 }
@@ -279,6 +286,7 @@ function usingDMY(name, values, func) {
         jasmine.currentEnv_.currentSpec.description += name;
     }
 }
+
 //describe("loadDataUrl() method", function () {
 //Bug: https://github.com/alterm4nn/ChronoZoom/issues/281
 //    describe("should return", function () {

--- a/Source/Chronozoom.UI/cz.js
+++ b/Source/Chronozoom.UI/cz.js
@@ -10,6 +10,7 @@
         Settings.zoomLevelFactor = 1.4;
         Settings.allowedVisibileImprecision = 0.00001;
         Settings.allowedMathImprecision = 0.0000001;
+        Settings.allowedMathImprecisionDecimals = parseInt(Settings.allowedMathImprecision.toExponential().split("-")[1]);
         Settings.canvasElementAnimationTime = 1300;
         Settings.canvasElementFadeInTime = 400;
         Settings.contentScaleMargin = 20;
@@ -3537,6 +3538,7 @@ var CZ;
             };
             var days = Dates.daysInMonth.reduce(sumDaysOfMonths, +(isLeap && month > 1)) + day;
             coord += (days - 1) / daysInYear;
+            coord = roundDecimal(coord, CZ.Settings.allowedMathImprecisionDecimals);
             return coord;
         }
         Dates.getCoordinateFromYMD = getCoordinateFromYMD;
@@ -3640,6 +3642,9 @@ var CZ;
             return years1;
         }
         Dates.numberofLeap = numberofLeap;
+        function roundDecimal(decimal, precision) {
+            return Math.round(decimal * Math.pow(10, precision)) / Math.pow(10, precision);
+        }
     })(CZ.Dates || (CZ.Dates = {}));
     var Dates = CZ.Dates;
 })(CZ || (CZ = {}));

--- a/Source/Chronozoom.UI/scripts/dates.js
+++ b/Source/Chronozoom.UI/scripts/dates.js
@@ -36,6 +36,7 @@ var CZ;
             };
             var days = Dates.daysInMonth.reduce(sumDaysOfMonths, +(isLeap && month > 1)) + day;
             coord += (days - 1) / daysInYear;
+            coord = roundDecimal(coord, CZ.Settings.allowedMathImprecisionDecimals);
             return coord;
         }
         Dates.getCoordinateFromYMD = getCoordinateFromYMD;
@@ -139,6 +140,9 @@ var CZ;
             return years1;
         }
         Dates.numberofLeap = numberofLeap;
+        function roundDecimal(decimal, precision) {
+            return Math.round(decimal * Math.pow(10, precision)) / Math.pow(10, precision);
+        }
     })(CZ.Dates || (CZ.Dates = {}));
     var Dates = CZ.Dates;
 })(CZ || (CZ = {}));

--- a/Source/Chronozoom.UI/scripts/dates.ts
+++ b/Source/Chronozoom.UI/scripts/dates.ts
@@ -1,3 +1,5 @@
+/// <reference path='settings.ts'/>
+
 module CZ {
     export module Dates {
 
@@ -45,6 +47,8 @@ module CZ {
             var days = daysInMonth.reduce(sumDaysOfMonths, +(isLeap && month > 1)) + day;
 
             coord += (days - 1) / daysInYear;
+
+            coord = roundDecimal(coord, CZ.Settings.allowedMathImprecisionDecimals);
 
             return coord;
         }
@@ -182,6 +186,10 @@ module CZ {
             years1 += Math.floor(year / 400) - Math.floor(startLeap / 400);
             if (isLeapYear(year)) years1--;
             return years1;
+        }
+
+        function roundDecimal(decimal, precision) {
+            return Math.round(decimal * Math.pow(10, precision)) / Math.pow(10, precision);
         }
     }
 }

--- a/Source/Chronozoom.UI/scripts/settings.js
+++ b/Source/Chronozoom.UI/scripts/settings.js
@@ -10,6 +10,7 @@ var CZ;
         Settings.zoomLevelFactor = 1.4;
         Settings.allowedVisibileImprecision = 0.00001;
         Settings.allowedMathImprecision = 0.0000001;
+        Settings.allowedMathImprecisionDecimals = parseInt(Settings.allowedMathImprecision.toExponential().split("-")[1]);
         Settings.canvasElementAnimationTime = 1300;
         Settings.canvasElementFadeInTime = 400;
         Settings.contentScaleMargin = 20;

--- a/Source/Chronozoom.UI/scripts/settings.ts
+++ b/Source/Chronozoom.UI/scripts/settings.ts
@@ -12,6 +12,7 @@
         export var zoomLevelFactor = 1.4;  //the step of the zooming
         export var allowedVisibileImprecision = 0.00001; // allowed imprecision in compare of two visibles
         export var allowedMathImprecision = 0.0000001; // allowed imprecision in float (10^-7)
+        export var allowedMathImprecisionDecimals = parseInt(allowedMathImprecision.toExponential().split("-")[1]); // allowedMathImprecision in decimals places
         export var canvasElementAnimationTime = 1300; //duration of animation of resize or transition of canvas element
         export var canvasElementFadeInTime = 400; // duration of fade in animation of newly added canvas element
 


### PR DESCRIPTION
Fix for https://github.com/alterm4nn/ChronoZoom/issues/746

Problem: Server only supports 8 decimals which is down to seconds-precision. However, client sends sub-second precision.

Fix: Reuse client constant (allowedMathImprecision) to round decimals to 7 decimals which the server currently supports. This could enable minute-precision timelines at some point.
