### PR TITLE
[BugFix] Fix tours. add Cache.Remove after Storage.SaveChanges in PutTour2 and DeleteTour.

### DIFF
--- a/Source/Chronozoom.UI/api/Chronozoom.svc.cs
+++ b/Source/Chronozoom.UI/api/Chronozoom.svc.cs
@@ -1458,6 +1458,7 @@ namespace Chronozoom.UI
                 }
 
                 storage.SaveChanges();
+                Cache.Remove(string.Format(CultureInfo.InvariantCulture, "Tour {0}", collection.Id));
                 return returnValue;
             });
         }
@@ -1604,6 +1605,7 @@ namespace Chronozoom.UI
                 DeleteBookmarks(storage, deleteTour);
                 storage.Tours.Remove(deleteTour);
                 storage.SaveChanges();
+                Cache.Remove(string.Format(CultureInfo.InvariantCulture, "Tour {0}", collection.Id));
             });
         }
 


### PR DESCRIPTION
Мясоеды, нужна помощь.
[7:19:41 PM] Sergey Berezin: Я исправил ошибки с добавлением и удаление туров.
[7:19:59 PM] Sergey Berezin: Но не могу залить реультаты.
[7:20:24 PM] Sergey Berezin: Git на ноутбуке не настроен, а скачивать по модему долго.
[7:20:33 PM] Sergey Berezin: Нужно внести два изменения:
[7:21:41 PM] Sergey Berezin: в файл \Source\Chronozoom.UI\api\Chronozoom.svc.cs
[7:22:22 PM] Sergey Berezin: 1) В методе PutTour2 надо добавить строку
[7:22:41 PM] Sergey Berezin: Cache.Remove(string.Format(CultureInfo.InvariantCulture, "Tour {0}", collection.Id));
[7:22:46 PM] Sergey Berezin: после
[7:22:50 PM] Sergey Berezin: Storage.SaveChanges
[7:24:49 PM] Sergey Berezin: 2) В методе DeleteTour то же самое.
[7:24:58 PM] Sergey Berezin: Добавить строку
[7:25:00 PM] Sergey Berezin: [7:22 PM] Sergey Berezin: 

<<< Cache.Remove(string.Format(CultureInfo.InvariantCulture, "Tour {0}", collection.Id));
после
Storage.SaveChanges
[7:25:34 PM] Sergey Berezin: Если я сумею настроить git, то смогу сделать и сам.
[7:25:52 PM] Sergey Berezin: Но если кто-то поможет, то это будет быстрее.
