### PR TITLE
URL validation and automatic Mimetype for all new and updated contentite...

### DIFF
--- a/Source/Chronozoom.UI/Web.config
+++ b/Source/Chronozoom.UI/Web.config
@@ -34,6 +34,8 @@
     <add key="TwitterConsumerSecret" value="" />
     <add key="TwitterAccessToken" value="" />
     <add key="TwitterAccessTokenSecret" value="" />
+    <add key="ImageMimetypes" value="image/png|image/jpeg|image/pjpeg|image/gif" />
+    <add key="PDFMimetype" value="application/pdf" />
   </appSettings>
   <system.web>
     <caching>


### PR DESCRIPTION
...ms.

These changes will verify that a url exists and is reachable from the server for all new contentitems.  It will also automatically set Mediatype based on the mimetype and url of the item.

If this code is added the following changes should be made:
delete "GetMemiTypeByUrl" from the API and change all client code that depends on it.
Client no longer sets Mediatype(various ui elements), instead that is handled by a (private to the api) function "ValidateContentItemUrl" when a contentitem is created or updated.

Client will currently still need to change youtube and vimeo links to embedded format but that should be moved to server.

http://mrccodereview.cloudapp.net/ui#review:id=4315
