### PR TITLE
API ref docs; regenerated to fix XML error 

### DIFF
--- a/Doc/ChronoZoom_REST_API.md
+++ b/Doc/ChronoZoom_REST_API.md
@@ -36,6 +36,7 @@ Use JSON for the request body:
 - [Storage](#storage)
 - [StorageMigrationsConfiguration](#storagemigrationsconfiguration)
 - [SuperCollection](#supercollection)
+- [Timeline](#timeline)
 - [User](#user)
 
 ### BookmarkType ###
@@ -253,6 +254,27 @@ Represents a set of collections.
 |Title|The title of the supercollection.|
 |User|The user who owns the supercollection.|
 |Collections|A collection of collections that belong to the supercollection.|
+ 
+[top](#chronozoom-rest-api-reference)
+ 
+----------
+ 
+### Timeline ###
+ 
+A visual representation of a time period that contains a set of Exhibits, child Timelines, and Time Series Data, and is contained by another Timeline or a Collection. The Timeline entity is externally searchable and linkable.
+ 
+|Property|Value|
+|:-------|:----|
+|Id|The ID of the timeline (GUID).|
+|Depth|The depth of the timeline in the timeline tree.|
+|SubtreeSize|The number of content items contained in subtree under current timeline.|
+|Title|The title of the timeline.|
+|Regime|The regime in which the timeline should occur.|
+|FromYear|The year the timeline begins.|
+|ToYear|The year the timeline ends.|
+|ForkNode|???|
+|ChildTimelines|The collection of child timelines belonging to the timeline.|
+|Exhibits|The collection of exhibits belonging to the timeline.|
  
 [top](#chronozoom-rest-api-reference)
  
@@ -881,7 +903,7 @@ A list of guids of the tour guid followed by bookmark guids in JSON format.
     HTTP verb: PUT
             
     URL:
-    http://{URL}/api/{supercollection}/{collection}/{collectionName}/tour2
+    http://{URL}/api/{supercollection}/{collection}/tour2
             
     Request body:
     {

--- a/Doc/tools/apicon/apicon/Program.cs
+++ b/Doc/tools/apicon/apicon/Program.cs
@@ -55,7 +55,9 @@ namespace apicon
             }
             else
             {
-                Console.WriteLine("One or more XML doc files could not be found. Check the settings file to make sure all paths are valid.");
+                Console.WriteLine("One or more XML doc files could not be found. Check the settings file to make sure all paths are valid. Press any key to exit.");
+                // Keep the console window open in debug mode.
+                Console.ReadKey();
             }
         }
 

--- a/Doc/tools/apicon/apicon/output/ChronoZoom_REST_API.md
+++ b/Doc/tools/apicon/apicon/output/ChronoZoom_REST_API.md
@@ -36,6 +36,7 @@ Use JSON for the request body:
 - [Storage](#storage)
 - [StorageMigrationsConfiguration](#storagemigrationsconfiguration)
 - [SuperCollection](#supercollection)
+- [Timeline](#timeline)
 - [User](#user)
 
 ### BookmarkType ###
@@ -253,6 +254,27 @@ Represents a set of collections.
 |Title|The title of the supercollection.|
 |User|The user who owns the supercollection.|
 |Collections|A collection of collections that belong to the supercollection.|
+ 
+[top](#chronozoom-rest-api-reference)
+ 
+----------
+ 
+### Timeline ###
+ 
+A visual representation of a time period that contains a set of Exhibits, child Timelines, and Time Series Data, and is contained by another Timeline or a Collection. The Timeline entity is externally searchable and linkable.
+ 
+|Property|Value|
+|:-------|:----|
+|Id|The ID of the timeline (GUID).|
+|Depth|The depth of the timeline in the timeline tree.|
+|SubtreeSize|The number of content items contained in subtree under current timeline.|
+|Title|The title of the timeline.|
+|Regime|The regime in which the timeline should occur.|
+|FromYear|The year the timeline begins.|
+|ToYear|The year the timeline ends.|
+|ForkNode|???|
+|ChildTimelines|The collection of child timelines belonging to the timeline.|
+|Exhibits|The collection of exhibits belonging to the timeline.|
  
 [top](#chronozoom-rest-api-reference)
  
@@ -881,7 +903,7 @@ A list of guids of the tour guid followed by bookmark guids in JSON format.
     HTTP verb: PUT
             
     URL:
-    http://{URL}/api/{supercollection}/{collection}/{collectionName}/tour2
+    http://{URL}/api/{supercollection}/{collection}/tour2
             
     Request body:
     {

--- a/Source/Chronozoom.Entities/Timeline.cs
+++ b/Source/Chronozoom.Entities/Timeline.cs
@@ -14,7 +14,7 @@ using System.Data.SqlTypes;
 namespace Chronozoom.Entities
 {
     /// <summary>
-    /// A visual representation of a time period that contains a set of Exhibits, child Timelines, and Time Series Data, and is contained by another Timeline or a Collection. The Timeline entity is externally searchable & linkable.
+    /// A visual representation of a time period that contains a set of Exhibits, child Timelines, and Time Series Data, and is contained by another Timeline or a Collection. The Timeline entity is externally searchable and linkable.
     /// </summary>
     [KnownType(typeof(TimelineRaw))]
     [KnownType(typeof(ExhibitRaw))]
@@ -29,12 +29,12 @@ namespace Chronozoom.Entities
         public Guid Id { get; set; }
 
         /// <summary>
-        /// The depth of the timeline in the timeline tree
+        /// The depth of the timeline in the timeline tree.
         /// </summary>
         public int Depth { get; set; }
 
         /// <summary>
-        /// The number of content items contained in subtree under current timeline
+        /// The number of content items contained in subtree under current timeline.
         /// </summary>
         public int SubtreeSize { get; set; }
 


### PR DESCRIPTION
Timeline entity documentation mysteriously disappeared. This was caused by an ampersand in the /// comments, which made the compiler omit the comment for Timeline. I removed the ampersand.
