### PR TITLE
Updated API doc tool.

### DIFF
--- a/Doc/tools/Using_API_Conversion_Tool.md
+++ b/Doc/tools/Using_API_Conversion_Tool.md
@@ -11,14 +11,15 @@ Everything begins with the paths, strings and regular expressions that are defin
 |MemberPath|Path to the XML documentation file for Chronozoom.UI.XML.|
 |EntityPath|Path to the XML documentation file for Chronozoom.Entities.XML.|
 |MemberClass|Prefix string for Chronozoom.UI members.|
-|MemberRgx|Regex for matching Chronozoom.UI members.|
 |EntityTypeClass|Prefix for Chronozoom.Entities types.|
-|EntityTypeRgx|Regex for matching Chronozoom.Entities members.|
 |EntityPropClass|Prefix string for Chronozoom.Entities properties.|
 |TopMatter|Path to the predefined top matter section.|
 |OutFile|Path to which the output file should be saved.|
 
 When APICON is run, the `makeDoc()` function is called first. This function groups together all of the other functions, and is responsible for generating the output file. APICON is built specifically to generate REST API documentation for the Chronozoom.UI and Chronozoom.Entities. Because of this, the two main functions (`getMembers()`, `getEntities()`) are specific to the APIs they convert (more about extensibility below).
+
+### A note about XML documentation file ###
+Code examples are presented within a CDATA block, which presents issues for Visual Studio as it parses the XML documentation file. Specifically, if there is a blank line in the triple-slash block (perfectly acceptable), there can NOT be any spaces. For some reason this interferes with the way Visual Studio indents the XML file. 
 
 ## Using APICON ##
 

--- a/Doc/tools/apicon/apicon/App.config
+++ b/Doc/tools/apicon/apicon/App.config
@@ -20,14 +20,8 @@
             <setting name="MemberClass" serializeAs="String">
                 <value>M:Chronozoom.UI.IChronozoomSVC.</value>
             </setting>
-            <setting name="MemberRgx" serializeAs="String">
-                <value>M:Chronozoom\.UI\.IChronozoomSVC\.\w*</value>
-            </setting>
             <setting name="EntityTypeClass" serializeAs="String">
                 <value>T:Chronozoom.Entities.</value>
-            </setting>
-            <setting name="EntityTypeRgx" serializeAs="String">
-                <value>T:Chronozoom\.Entities\.\w*</value>
             </setting>
             <setting name="EntityPropClass" serializeAs="String">
                 <value>P:Chronozoom.Entities.</value>
@@ -40,6 +34,18 @@
             </setting>
             <setting name="OutFile2" serializeAs="String">
                 <value>C:\Users\v-wfren\Documents\GitHub\ChronoZoom\Doc\ChronoZoom_REST_API.md</value>
+            </setting>
+            <setting name="ExcludeList" serializeAs="Xml">
+                <value>
+                    <ArrayOfString xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                        xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+                        <string>entityPropRgx</string>
+                        <string>RemoveRITree</string>
+                        <string>AddRITreeWithIndex</string>
+                        <string>Properties.Resources</string>
+                        <string>RemoveBetaFields</string>
+                    </ArrayOfString>
+                </value>
             </setting>
         </apicon.Properties.Settings>
         <xslcon.Properties.Settings>

--- a/Doc/tools/apicon/apicon/Properties/Settings.Designer.cs
+++ b/Doc/tools/apicon/apicon/Properties/Settings.Designer.cs
@@ -54,28 +54,10 @@ namespace apicon.Properties {
         
         [global::System.Configuration.ApplicationScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("M:Chronozoom\\.UI\\.IChronozoomSVC\\.\\w*")]
-        public string MemberRgx {
-            get {
-                return ((string)(this["MemberRgx"]));
-            }
-        }
-        
-        [global::System.Configuration.ApplicationScopedSettingAttribute()]
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("T:Chronozoom.Entities.")]
         public string EntityTypeClass {
             get {
                 return ((string)(this["EntityTypeClass"]));
-            }
-        }
-        
-        [global::System.Configuration.ApplicationScopedSettingAttribute()]
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("T:Chronozoom\\.Entities\\.\\w*")]
-        public string EntityTypeRgx {
-            get {
-                return ((string)(this["EntityTypeRgx"]));
             }
         }
         
@@ -113,6 +95,22 @@ namespace apicon.Properties {
         public string OutFile2 {
             get {
                 return ((string)(this["OutFile2"]));
+            }
+        }
+        
+        [global::System.Configuration.ApplicationScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute(@"<?xml version=""1.0"" encoding=""utf-16""?>
+<ArrayOfString xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"">
+  <string>entityPropRgx</string>
+  <string>RemoveRITree</string>
+  <string>AddRITreeWithIndex</string>
+  <string>Properties.Resources</string>
+  <string>RemoveBetaFields</string>
+</ArrayOfString>")]
+        public global::System.Collections.Specialized.StringCollection ExcludeList {
+            get {
+                return ((global::System.Collections.Specialized.StringCollection)(this["ExcludeList"]));
             }
         }
     }

--- a/Doc/tools/apicon/apicon/Properties/Settings.settings
+++ b/Doc/tools/apicon/apicon/Properties/Settings.settings
@@ -11,14 +11,8 @@
     <Setting Name="MemberClass" Type="System.String" Scope="Application">
       <Value Profile="(Default)">M:Chronozoom.UI.IChronozoomSVC.</Value>
     </Setting>
-    <Setting Name="MemberRgx" Type="System.String" Scope="Application">
-      <Value Profile="(Default)">M:Chronozoom\.UI\.IChronozoomSVC\.\w*</Value>
-    </Setting>
     <Setting Name="EntityTypeClass" Type="System.String" Scope="Application">
       <Value Profile="(Default)">T:Chronozoom.Entities.</Value>
-    </Setting>
-    <Setting Name="EntityTypeRgx" Type="System.String" Scope="Application">
-      <Value Profile="(Default)">T:Chronozoom\.Entities\.\w*</Value>
     </Setting>
     <Setting Name="EntityPropClass" Type="System.String" Scope="Application">
       <Value Profile="(Default)">P:Chronozoom.Entities.</Value>
@@ -31,6 +25,16 @@
     </Setting>
     <Setting Name="OutFile2" Type="System.String" Scope="Application">
       <Value Profile="(Default)">C:\Users\v-wfren\Documents\GitHub\ChronoZoom\Doc\ChronoZoom_REST_API.md</Value>
+    </Setting>
+    <Setting Name="ExcludeList" Type="System.Collections.Specialized.StringCollection" Scope="Application">
+      <Value Profile="(Default)">&lt;?xml version="1.0" encoding="utf-16"?&gt;
+&lt;ArrayOfString xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"&gt;
+  &lt;string&gt;entityPropRgx&lt;/string&gt;
+  &lt;string&gt;RemoveRITree&lt;/string&gt;
+  &lt;string&gt;AddRITreeWithIndex&lt;/string&gt;
+  &lt;string&gt;Properties.Resources&lt;/string&gt;
+  &lt;string&gt;RemoveBetaFields&lt;/string&gt;
+&lt;/ArrayOfString&gt;</Value>
     </Setting>
   </Settings>
 </SettingsFile>

--- a/Source/Chronozoom.UI/api/IChronozoomSVC.cs
+++ b/Source/Chronozoom.UI/api/IChronozoomSVC.cs
@@ -34,13 +34,11 @@ namespace Chronozoom.UI
         /// <param name="maxElements">The maximum number of elements to return.</param>
         /// <param name="depth">The max depth for children timelines.</param>
         /// <returns>Timeline data in JSON format.</returns>
-        /// <example><![CDATA[ 
+        /// <example><![CDATA[  
         /// HTTP verb: GET
-        ///
         /// URL:
         /// http://{URL}/api/gettimelines?supercollection={supercollection}&collection={collection}&start={year}&end={year}
-        /// ]]>
-        /// </example>
+        /// ]]></example>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "End")]
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "minspan")]
         [OperationContract]
@@ -57,13 +55,11 @@ namespace Chronozoom.UI
         /// <param name="collection">Name of the collection to query.</param>
         /// <param name="searchTerm">The term to search for.</param>
         /// <returns>Search results in JSON format.</returns>
-        /// <example><![CDATA[ 
+        /// <example><![CDATA[  
         /// HTTP verb: GET
-        ///
         /// URL:
         /// http://{URL}/api/search?searchTerm={term}&supercollection={supercollection}&collection={collection}
-        /// ]]>
-        /// </example>
+        /// ]]></example>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures")]
         [OperationContract]
         [WebGet(ResponseFormat = WebMessageFormat.Json)]
@@ -73,13 +69,11 @@ namespace Chronozoom.UI
         /// Returns a list of tours for the default collection and default superCollection.
         /// </summary>
         /// <returns>A list of tours in JSON format.</returns>
-        /// <example><![CDATA[ 
+        /// <example><![CDATA[  
         /// HTTP verb: GET
-        ///
         /// URL: 
         /// http://{URL}/api/tours
-        /// ]]>
-        /// </example>
+        /// ]]></example>
         [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures")]
         [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
         [OperationContract]
@@ -92,13 +86,11 @@ namespace Chronozoom.UI
         /// <param name="superCollection">Name of the superCollection to query.</param>
         /// <param name="collection">Name of the collection to query.</param>
         /// <returns>A list of tours in JSON format.</returns>
-        /// <example><![CDATA[ 
+        /// <example><![CDATA[  
         /// HTTP verb: GET
-        ///
         /// URL: 
         /// http://{URL}/api/{supercollection}/{collection}/tours
-        /// ]]>
-        /// </example>
+        /// ]]></example>
         [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures")]
         [SuppressMessage("Microsoft.Maintainability", "CA1506:AvoidExcessiveClassCoupling")]
         [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate", Justification = "Not appropriate")]
@@ -116,26 +108,23 @@ namespace Chronozoom.UI
         /// A new superCollection with the user's display name is added.
         /// A new default collection with the user's display name is added to this superCollection.
         /// A new user with the specified attributes is created.
-        ///
         /// If the specified user display name does not exist it is considered an error.
         /// If the user display name is specified and it exists then the user's attributes are updated.
         /// </remarks>
         /// <param name="userRequest">JSON containing the request details.</param>
         /// <returns>The URL for the new user collection.</returns>
-        /// <example><![CDATA[ 
+        /// <example><![CDATA[  
         /// HTTP verb: PUT
-        ///
         /// URL:
         /// http://{URL}/api/{supercollection}/{collection}/user
         /// 
-        /// Request body (JSON):
+        /// Request body:
         /// {
         ///     id: "0123456789",
         ///     displayName: "Joe",
         ///     email: "email@email.com"
         /// }
-        /// ]]>
-        /// </example>
+        /// ]]></example>
         [OperationContract]
         [WebInvoke(Method = "PUT", UriTemplate = "/user", RequestFormat = WebMessageFormat.Json, ResponseFormat = WebMessageFormat.Json)]
         String PutUser(User userRequest);
@@ -154,18 +143,16 @@ namespace Chronozoom.UI
         /// </summary>
         /// <param name="userRequest">JSON containing the request details.</param>
         /// <returns>HTTP response code.</returns>
-        /// <example><![CDATA[ 
+        /// <example><![CDATA[  
         /// HTTP verb: DELETE
-        /// 
         /// URL:
         /// http://{URL}/api/{supercollection}/{collection}/user
-        /// 
-        /// Request body (JSON):
+        ///
+        /// Request body:
         /// {
         ///     displayName: "Neil"
         /// }
-        /// ]]>
-        /// </example>
+        /// ]]></example>
         [OperationContract]
         [WebInvoke(Method = "DELETE", UriTemplate = "/user", RequestFormat = WebMessageFormat.Json, ResponseFormat = WebMessageFormat.Json)]
         void DeleteUser(User userRequest);
@@ -173,18 +160,13 @@ namespace Chronozoom.UI
         /// <summary>
         /// Returns the user by name, if name parameter is empty returns current user.
         /// </summary>
-        /// <example>
-        /// <![CDATA[
-        /// HTTP verb: GET
-        /// 
-        /// URL:
-        /// http://{URL}/api/user
-        /// ]]>
-        /// </example>
         /// <param name="name">The name of user to get.</param>
         /// <returns>JSON containing data for the current user.</returns>
-        /// 
-      
+        /// <example><![CDATA[ 
+        /// HTTP verb: GET
+        /// URL:
+        /// http://{URL}/api/user
+        /// ]]></example>      
         [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
         [OperationContract]
         [WebInvoke(Method = "GET", UriTemplate = "/user?name={name}", RequestFormat = WebMessageFormat.Json, ResponseFormat = WebMessageFormat.Json)]
@@ -202,19 +184,17 @@ namespace Chronozoom.UI
         /// <param name="collectionName">The name of the collection to create.</param>
         /// <param name="collectionRequest">[Collection](#collection) data in JSON format.</param>
         /// <returns></returns>
-        /// <example><![CDATA[ 
-        /// HTTP verb: PUT
-        ///
+        /// <example><![CDATA[  
+        /// HTTP verb: POST
         /// URL:
         /// http://{URL}/api/{supercollection}/{collection}
         ///
-        /// Request body (JSON):
+        /// Request body:
         /// {
         ///      id: "{id}",
         ///      title: "{title}"
         /// }
-        /// ]]>
-        /// </example>
+        /// ]]></example>
         [OperationContract]
         [WebInvoke(Method = "POST", UriTemplate = "/{superCollectionName}/{collectionName}", RequestFormat = WebMessageFormat.Json, ResponseFormat = WebMessageFormat.Json)]
         Guid PostCollection(string superCollectionName, string collectionName, Collection collectionRequest);
@@ -231,19 +211,17 @@ namespace Chronozoom.UI
         /// <param name="collectionName">The name of the collection to create.</param>
         /// <param name="collectionRequest">[Collection](#collection) data in JSON format.</param>
         /// <returns></returns>
-        /// <example><![CDATA[ 
+        /// <example><![CDATA[  
         /// HTTP verb: PUT
-        ///
         /// URL:
         /// http://{URL}/api/{supercollection}/{collection}
         ///
-        /// Request body (JSON):
+        /// Request body:
         /// {
         ///      id: "{id}",
         ///      title: "{title}"
         /// }
-        /// ]]>
-        /// </example>
+        /// ]]></example>
         [OperationContract]
         [WebInvoke(Method = "PUT", UriTemplate = "/{superCollectionName}/{collectionName}", RequestFormat = WebMessageFormat.Json, ResponseFormat = WebMessageFormat.Json)]
         Guid PutCollection(string superCollectionName, string collectionName, Collection collectionRequest);
@@ -254,13 +232,11 @@ namespace Chronozoom.UI
         /// <param name="superCollectionName">The name of the parent collection.</param>
         /// <param name="collectionName">The name of the collection to delete.</param>
         /// <returns>HTTP response code.</returns>
-        /// <example><![CDATA[ 
+        /// <example><![CDATA[  
         /// HTTP verb: DELETE
-        ///
         /// URL:
         /// http://{URL}/api/{supercollection}/{collection}
-        /// ]]>
-        /// </example>
+        /// ]]></example>
         [OperationContract]
         [WebInvoke(Method = "DELETE", UriTemplate = "/{superCollectionName}/{collectionName}", RequestFormat = WebMessageFormat.Json, ResponseFormat = WebMessageFormat.Json)]
         void DeleteCollection(string superCollectionName, string collectionName);
@@ -278,13 +254,12 @@ namespace Chronozoom.UI
         /// <param name="collectionName">The name of the collection to update.</param>
         /// <param name="timelineRequest">[Timeline](#timeline) data in JSON format.</param>
         /// <returns>HTTP status code.</returns>
-        /// <example><![CDATA[ 
+        /// <example><![CDATA[  
         /// HTTP verb: PUT
-        ///
         /// URL:
         /// http://{URL}/api/{supercollection}/{collection}/timeline
         ///
-        /// Request body (JSON):
+        /// Request body:
         /// {
         ///      ParentTimelineId: "ff5214e1-1bf4-4af5-8835-96cff2ce2cfd",
         ///      Regime: null - optional,
@@ -292,8 +267,7 @@ namespace Chronozoom.UI
         ///      start: -597.542466,
         ///      title: "Timeline Title"
         /// }
-        /// ]]>
-        /// </example>
+        /// ]]></example>
         [OperationContract]
         [WebInvoke(Method = "PUT", UriTemplate = "/{superCollectionName}/{collectionName}/timeline", RequestFormat = WebMessageFormat.Json, ResponseFormat = WebMessageFormat.Json)]
         Guid PutTimeline(string superCollectionName, string collectionName, TimelineRaw timelineRequest);
@@ -304,18 +278,16 @@ namespace Chronozoom.UI
         /// <param name="superCollectionName">The name of the parent collection.</param>
         /// <param name="collectionName">The name of the collection from which the timeline should be deleted.</param>
         /// <param name="timelineRequest">The request in JSON format.</param>
-        /// <example><![CDATA[ 
+        /// <example><![CDATA[  
         /// HTTP verb: DELETE
-        ///
         /// URL:
         /// http://{URL}/api/{supercollection}/{collection}/timeline
         ///
-        /// Request body (JSON):
+        /// Request body:
         /// {
         ///      id: "0123456789"
         /// }
-        /// ]]>
-        /// </example>
+        /// ]]></example>
         [OperationContract]
         [WebInvoke(Method = "DELETE", UriTemplate = "/{superCollectionName}/{collectionName}/timeline", RequestFormat = WebMessageFormat.Json, ResponseFormat = WebMessageFormat.Json)]
         void DeleteTimeline(string superCollectionName, string collectionName, Timeline timelineRequest);
@@ -335,13 +307,12 @@ namespace Chronozoom.UI
         /// <param name="collectionName">The name of the collection to modify.</param>
         /// <param name="exhibitRequest">[Exhibit](#exhibit) data in JSON format.</param>
         /// <returns>[Exhibit](#exhibit) data in JSON format.</returns>
-        /// <example><![CDATA[ 
+        /// <example><![CDATA[  
         /// HTTP verb: PUT
-        ///
         /// URL:
         /// http://{URL}/api/{supercollection}/{collection}/exhibit
         ///
-        /// Request body (JSON):
+        /// Request body:
         /// {
         ///     ParentTimelineId: "123456"
         ///     id: "0123456789",
@@ -349,8 +320,7 @@ namespace Chronozoom.UI
         ///     contentItems: "{contentItems}" 
         ///     time: 565
         /// }
-        /// ]]>
-        /// </example>
+        /// ]]></example>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1506:AvoidExcessiveClassCoupling")]
         [OperationContract]
         [WebInvoke(Method = "PUT", UriTemplate = "/{superCollectionName}/{collectionName}/exhibit", RequestFormat = WebMessageFormat.Json, ResponseFormat = WebMessageFormat.Json)]
@@ -362,9 +332,8 @@ namespace Chronozoom.UI
         /// <param name="superCollectionName">The name of the parent collection.</param>
         /// <param name="collectionName">The name of the collection to modify.</param>
         /// <param name="exhibitRequest">The exhibit request data in JSON format.</param>
-        /// <example><![CDATA[ 
+        /// <example><![CDATA[  
         /// HTTP verb: DELETE
-        ///
         /// URL:
         /// http://{URL}/api/{supercollection}/{collection}/exhibit
         ///
@@ -384,12 +353,11 @@ namespace Chronozoom.UI
         /// <param name="collectionName">The name of the collection to modify.</param>
         /// <param name="contentItemRequest">[ContentItem](#contentitem) data in JSON format.</param>
         /// <returns></returns>
-        /// <example><![CDATA[ 
+        /// <example><![CDATA[  
         /// HTTP verb: PUT
-        ///
         /// URL:
         /// http://{URL}/api/{supercollection}/{collection}/contentitem
-        ///
+        ///              
         /// Request body:
         /// {
         ///     id: "0123456789",
@@ -407,9 +375,8 @@ namespace Chronozoom.UI
         /// <param name="superCollectionName">The name of the parent collection.</param>
         /// <param name="collectionName">The name of the collection to modify.</param>
         /// <param name="contentItemRequest">The request data in JSON format.</param>
-        /// <example><![CDATA[ 
+        /// <example><![CDATA[  
         /// HTTP verb: DELETE
-        ///
         /// URL:
         /// http://{URL}/api/{supercollection}/{collection}/contentitem
         ///
@@ -417,8 +384,7 @@ namespace Chronozoom.UI
         /// {
         ///      id: "0123456789"
         /// }
-        /// ]]>
-        /// </example>
+        /// ]]></example>
         [OperationContract]
         [WebInvoke(Method = "DELETE", UriTemplate = "/{superCollectionName}/{collectionName}/contentitem", RequestFormat = WebMessageFormat.Json, ResponseFormat = WebMessageFormat.Json)]
         void DeleteContentItem(string superCollectionName, string collectionName, ContentItem contentItemRequest);
@@ -444,16 +410,14 @@ namespace Chronozoom.UI
         /// If a tour id is specified and it exists, any specified fields are updated. 
         /// Delete all existing bookmarks and add bookmarks defined in the bookmarks JSON object to the tour.
         /// The sequence ids of the bookmarks are automatically generated based on the order they are received.
-        ///     
         /// If an invalid tour Id, bookmark Id or bookmark sequence Id is specified then the request will fail. 
         /// </remarks>
         /// <param name="superCollectionName">The name of the parent collection.</param>
         /// <param name="collectionName">The name of the collection to modify.</param>
         /// <param name="tourRequest">The tour data in JSON format.</param>
         /// <returns>A list of guids of the tour guid followed by bookmark guids in JSON format.</returns>
-        /// <example><![CDATA[ 
+        /// <example><![CDATA[  
         /// HTTP verb: PUT
-        ///
         /// URL:
         /// http://{URL}/api/{supercollection}/{collection}/tour2
         ///
@@ -461,8 +425,7 @@ namespace Chronozoom.UI
         /// {
         ///          
         /// }
-        /// ]]>
-        /// </example>
+        /// ]]></example>
         [OperationContract]
         [WebInvoke(Method = "PUT", UriTemplate = "/{superCollectionName}/{collectionName}/tour2", RequestFormat = WebMessageFormat.Json, ResponseFormat = WebMessageFormat.Json)]
         TourResult PutTour2(string superCollectionName, string collectionName, Tour tourRequest);
@@ -473,9 +436,8 @@ namespace Chronozoom.UI
         /// <param name="superCollectionName">The name of the parent collection.</param>
         /// <param name="collectionName">The name of the collection to modify.</param>
         /// <param name="tourRequest">The tour ID in JSON format.</param>
-        /// <example><![CDATA[ 
+        /// <example><![CDATA[  
         /// HTTP verb: DELETE
-        ///
         /// URL:
         /// http://{URL}/api/{supercollection}/{collection}/tour2
         ///
@@ -495,9 +457,8 @@ namespace Chronozoom.UI
         /// <param name="collectionName">The name of the collection to modify.</param>
         /// <param name="tourRequest">The request in JSON format.</param>
         /// <returns>A list of guids of tour guid followed by new bookmark guids in JSON format.</returns>
-        /// <example><![CDATA[ 
-        /// HTTP verb: DELETE
-        ///
+        /// <example><![CDATA[  
+        /// HTTP verb: PUT
         /// URL:
         /// http://{URL}/api/{supercollection}/{collection}/{collectionName}/bookmark
         ///
@@ -505,8 +466,7 @@ namespace Chronozoom.UI
         /// {
         ///      id: "0123456789"
         /// }
-        /// ]]>
-        /// </example>
+        /// ]]></example>
         [OperationContract]
         [WebInvoke(Method = "PUT", UriTemplate = "/{superCollectionName}/{collectionName}/bookmark", RequestFormat = WebMessageFormat.Json, ResponseFormat = WebMessageFormat.Json)]
         TourResult PutBookmarks(string superCollectionName, string collectionName, Tour tourRequest);
@@ -517,9 +477,8 @@ namespace Chronozoom.UI
         /// <param name="superCollectionName">The name of the parent collection.</param>
         /// <param name="collectionName">The name of the collection to modify.</param>
         /// <param name="tourRequest">The request in JSON format.</param>
-        /// <example><![CDATA[ 
+        /// <example><![CDATA[
         /// HTTP verb: DELETE
-        ///
         /// URL:
         /// http://{URL}/api/{supercollection}/{collection}/bookmark
         ///
@@ -527,25 +486,20 @@ namespace Chronozoom.UI
         /// {
         ///      id: "0123456789"
         /// }
-        /// ]]>
-        /// </example>
+        /// ]]></example>
         [OperationContract]
         [WebInvoke(Method = "DELETE", UriTemplate = "/{superCollectionName}/{collectionName}/bookmark", RequestFormat = WebMessageFormat.Json, ResponseFormat = WebMessageFormat.Json)]
         void DeleteBookmarks(string superCollectionName, string collectionName, Tour tourRequest);
 
         /// <summary>
-        /// Retrieves a path to the given content id.
-        /// 
-        /// For t48fbb8a8-7c5d-49c3-83e1-98939ae2ae6, this API retrieves /t00000000-0000-0000-0000-000000000000/t48fbb8a8-7c5d-49c3-83e1-98939ae2ae67
+        /// Retrieves a path to the given content id. For t48fbb8a8-7c5d-49c3-83e1-98939ae2ae6, this API retrieves /t00000000-0000-0000-0000-000000000000/t48fbb8a8-7c5d-49c3-83e1-98939ae2ae67
         /// </summary>
         /// <returns>The full path to the content.</returns>
         /// <example><![CDATA[
         /// HTTP verb: GET
-        /// 
         /// URL:
         /// http://{URL}/api/{supercollection}/{collection}/{reference}/contentpath
-        /// ]]>
-        /// </example>
+        /// ]]></example>
         [OperationContract]
         [WebGet(ResponseFormat = WebMessageFormat.Json, UriTemplate = "{supercollection}/{collection}/{reference}/contentpath")]
         string GetContentPath(string superCollection, string collection, string reference);
@@ -553,13 +507,11 @@ namespace Chronozoom.UI
         /// <summary>
         /// Retrieve the list of all supercollections.
         /// </summary>
-        /// <example><![CDATA[ 
+        /// <example><![CDATA[  
         /// HTTP verb: GET
-        ///
         /// URL:
         /// http://{URL}/api/supercollections
-        /// ]]>
-        /// </example>
+        /// ]]></example>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
         [OperationContract]
         [WebGet(UriTemplate = "/supercollections", ResponseFormat = WebMessageFormat.Json)]
@@ -568,13 +520,11 @@ namespace Chronozoom.UI
         /// <summary>
         /// Retrieve the list of all collections.
         /// </summary>
-        /// <example><![CDATA[ 
+        /// <example><![CDATA[  
         /// HTTP verb: GET
-        ///
         /// URL:
         /// http://{URL}/api/{superCollection}/collections
-        /// ]]>
-        /// </example>
+        /// ]]></example>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
         [OperationContract]
         [WebGet(UriTemplate = "/{superCollectionName}/collections", ResponseFormat = WebMessageFormat.Json)]
@@ -583,13 +533,11 @@ namespace Chronozoom.UI
         /// <summary>
         /// Retrieve file mime type by url
         /// </summary>
-        /// <example><![CDATA[ 
+        /// <example><![CDATA[  
         /// HTTP verb: GET
-        ///
         /// URL:
         /// http://{URL}/api/mimetypebyurl
-        /// ]]>
-        /// </example>
+        /// ]]></example>
         [OperationContract]
         [WebInvoke(Method = "GET", UriTemplate = "/mimetypebyurl?url={url}", ResponseFormat = WebMessageFormat.Json)]
         string GetMimeTypeByUrl(string url);
@@ -656,13 +604,12 @@ namespace Chronozoom.UI
         /// <param name="top">The number of the results to return.</param>
         /// <param name="skip">The offset requested for the srarting point of returned results.</param>
         /// <returns>Search results (images) in JSON format.</returns>
-        /// <example><![CDATA[ 
+        /// <example><![CDATA[  
         /// HTTP verb: GET
-        ///
         /// URL:
         /// http://{URL}/api/bing/getImages?query={query}&top={top}&skip={skip}
-        /// ]]>
-        /// </example>
+        /// 
+        /// ]]></example>
         [OperationContract]
         [WebGet(ResponseFormat = WebMessageFormat.Json)]
         BaseJsonResult<IEnumerable<Bing.ImageResult>> GetImages(string query, string top, string skip);
@@ -674,13 +621,12 @@ namespace Chronozoom.UI
         /// <param name="top">The number of the results to return.</param>
         /// <param name="skip">The offset requested for the srarting point of returned results.</param>
         /// <returns>Search results (videos) in JSON format.</returns>
-        /// <example><![CDATA[ 
+        /// <example><![CDATA[  
         /// HTTP verb: GET
-        ///
         /// URL:
         /// http://{URL}/api/bing/getVideos?query={query}&top={top}&skip={skip}
-        /// ]]>
-        /// </example>
+        /// 
+        /// ]]></example>
         [OperationContract]
         [WebGet(ResponseFormat = WebMessageFormat.Json)]
         BaseJsonResult<IEnumerable<Bing.VideoResult>> GetVideos(string query, string top, string skip);
@@ -693,13 +639,12 @@ namespace Chronozoom.UI
         /// <param name="top">The number of the results to return.</param>
         /// <param name="skip">The offset requested for the srarting point of returned results.</param>
         /// <returns>Search results (documents) in JSON format.</returns>
-        /// <example><![CDATA[ 
+        /// <example><![CDATA[  
         /// HTTP verb: GET
-        ///
         /// URL:
         /// http://{URL}/api/bing/getDocuments?query={query}&doctype={doctype}&top={top}&skip={skip}
-        /// ]]>
-        /// </example>
+        /// 
+        /// ]]></example>
         [OperationContract]
         [WebGet(ResponseFormat = WebMessageFormat.Json)]
         BaseJsonResult<IEnumerable<Bing.WebResult>> GetDocuments(string query, string doctype, string top, string skip);
@@ -712,13 +657,12 @@ namespace Chronozoom.UI
         /// Returns recent N timeline tweets of ChronoZoom Twitter account.
         /// </summary>
         /// <returns>Recent N timeline tweets of ChronoZoom Twitter account in JSON format.</returns>
-        /// <example><![CDATA[ 
+        /// <example><![CDATA[  
         /// HTTP verb: GET
-        ///
         /// URL:
         /// http://{URL}/api/twitter/getRecentTweets
-        /// ]]>
-        /// </example>
+        /// 
+        /// ]]></example>
         [OperationContract]
         [WebGet(ResponseFormat = WebMessageFormat.Json)]
         BaseJsonResult<IEnumerable<TweetSharp.TwitterStatus>> GetRecentTweets();


### PR DESCRIPTION
Tool improvements:
- Now regexes are autogenerated to save time and effort (before you had to enter them in config settings but that was a bit redundant).
- Added ability to exclude members by name.
- Fixed an issue where CDATA regions were being improperly indented.
- Cleaned up formatting of triple-slash comments in IChronozoomsvc.cs
