### PR TITLE
Add support to edit collection backgrounds

### DIFF
--- a/Source/Chronozoom.UI/Chronozoom.UI.csproj
+++ b/Source/Chronozoom.UI/Chronozoom.UI.csproj
@@ -387,6 +387,7 @@
       <DependentUpon>utility-plugins.ts</DependentUpon>
     </Content>
     <TypeScriptCompile Include="scripts\plugins\utility-plugins.ts" />
+    <Content Include="ui\auth-edit-collection-form.html" />
     <Content Include="ui\auth-edit-tour-form.html" />
     <Content Include="ui\auth-edit-tour-form.js">
       <DependentUpon>auth-edit-tour-form.ts</DependentUpon>
@@ -474,6 +475,10 @@
     <TypeScriptCompile Include="ui\auth-edit-timeline-form.ts" />
     <Content Include="ui\auth-edit-timeline-form.js">
       <DependentUpon>auth-edit-timeline-form.ts</DependentUpon>
+    </Content>
+    <TypeScriptCompile Include="ui\auth-edit-collection-form.ts" />
+    <Content Include="ui\auth-edit-collection-form.js">
+      <DependentUpon>auth-edit-collection-form.ts</DependentUpon>
     </Content>
     <Content Include="ui\auth-edit-timeline-form.html" />
     <Content Include="ui\contentitem-listbox.html" />

--- a/Source/Chronozoom.UI/css/cz.css
+++ b/Source/Chronozoom.UI/css/cz.css
@@ -2282,6 +2282,22 @@ img.fallbackBackground {
   left: 0;
   overflow-y: auto;
 }
+/* Edit Collection Form */
+.cz-collection-form
+{
+    width: 420px;
+    bottom: 25px;
+    left: 0;
+}
+.cz-collection-form > .cz-form-content
+{
+    position: absolute;
+    top: 36px;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    overflow-y: auto;
+}
 /* Profile Form */
 #profile-form {
   right: 0;
@@ -2705,4 +2721,16 @@ img.fallbackBackground {
 }
 .root-cloak-bottom.visible {
   display: block;
+}
+
+#editCollectionButton {
+    position: absolute;
+    width: 50px;
+    height: 50px;
+    z-index: 100;
+    margin-top: -50px;
+}
+#editCollectionButton > img {
+    width: 50px;
+    height: 50px;
 }

--- a/Source/Chronozoom.UI/css/cz.less
+++ b/Source/Chronozoom.UI/css/cz.less
@@ -1573,6 +1573,24 @@ img.fallbackBackground
         color: #fff;
     }
 
+/* Edit Collection Form */
+.cz-collection-form
+{
+    width: 420px;
+    bottom: 25px;
+    left: 0;
+}
+
+    .cz-collection-form > .cz-form-content
+    {
+        position: absolute;
+        top: 36px;
+        right: 0;
+        bottom: 0;
+        left: 0;
+        overflow-y: auto;
+    }
+
 .auth-panel-login
 {
     display: inline-block;
@@ -2037,4 +2055,16 @@ img.fallbackBackground
   bottom: @footerHeight;
   left: 0;
   right: 0;
+}
+
+#editCollectionButton {
+    position: absolute;
+    width: 50px;
+    height: 50px;
+    z-index: 100;
+    margin-top: -50px;
+}
+#editCollectionButton > img {
+    width: 50px;
+    height: 50px;
 }

--- a/Source/Chronozoom.UI/cz.html
+++ b/Source/Chronozoom.UI/cz.html
@@ -99,6 +99,7 @@
                 AddScript("/ui/auth-edit-exhibit-form.js");
                 AddScript("/ui/auth-edit-contentitem-form.js");
                 AddScript("/ui/auth-edit-tour-form.js");
+                AddScript("/ui/auth-edit-collection-form.js");
                 AddScript("/ui/header-edit-form.js");
                 AddScript("/ui/header-edit-profile-form.js");
                 AddScript("/ui/header-login-form.js");
@@ -225,7 +226,9 @@
             <div class="root-cloak-right" title="You can't create event here"></div>
             <div class="root-cloak-bottom" title="You can't create event here"></div>
             <div class="root-cloak-left" title="You can't create event here"></div>
-
+            <div id="editCollectionButton" style="display: none">
+                <img src="/images/edit.svg" />
+            </div>
             <div id="timeSeriesContainer" style="display: none;"></div>
         </div>
                 
@@ -249,6 +252,7 @@
         <div id="timeSeriesDataForm" class="cz-form cz-form-right cz-major-form unselectable"></div>
         <div id="toursList" class="cz-form cz-form-right cz-major-form cz-tourlist-form unselectable"></div>
         <div id="tour-caption-form" class="cz-form cz-form-left cz-major-form cz-tour-caption-form unselectable"></div>
+        <div id="auth-edit-collection-form" class="cz-form cz-form-left cz-major-form cz-collection-form unselectable"></div>
         <div id="auth-edit-timeline-form" class="cz-form cz-form-left cz-form-timeline unselectable"></div>
         <div id="auth-edit-exhibit-form" class="cz-form cz-form-left cz-form-exhibit unselectable"></div>
         <div id="auth-edit-contentitem-form" class="cz-form cz-form-left cz-form-contentitem unselectable"></div>

--- a/Source/Chronozoom.UI/cz.js
+++ b/Source/Chronozoom.UI/cz.js
@@ -165,44 +165,22 @@
         }());
 
         Settings.theme;
-        function applyTheme(theme) {
-            if (!theme) {
-                theme = "cosmos";
-            }
-
-            this.theme = theme;
-            var themeData = {
-                "cosmos": {
-                    "background": "url('/images/background.jpg')",
-                    "backgroundColor": "#232323",
-                    "timelineColor": null,
-                    "timelineHoverAnimation": 3 / 60.0,
-                    "infoDotFillColor": 'rgb(92,92,92)',
-                    "fallbackImageUri": '/images/Temp-Thumbnail2.png',
-                    "timelineGradientFillStyle": null
-                },
-                "gray": {
-                    "background": "none",
-                    "backgroundColor": "#bebebe",
-                    "timelineColor": null,
-                    "timelineHoverAnimation": 3 / 60.0,
-                    "infoDotFillColor": 'rgb(92,92,92)',
-                    "fallbackImageUri": '/images/Temp-Thumbnail2.png',
-                    "timelineGradientFillStyle": "#9e9e9e"
-                },
-                "aqua": {
-                    "background": "none",
-                    "backgroundColor": "rgb(238, 238, 238)",
-                    "timelineColor": "rgba(52, 76, 130, 0.5)",
-                    "timelineHoverAnimation": 3 / 60.0,
-                    "infoDotFillColor": 'rgb(55,84,123)',
-                    "fallbackImageUri": '/images/Temp-Thumbnail-Aqua.png',
-                    "timelineGradientFillStyle": "rgb(80,123,175)"
-                }
+        function applyTheme(theme, delayLoad) {
+            this.theme = {
+                "backgroundUrl": delayLoad ? "" : "/images/background.jpg",
+                "backgroundColor": "#232323",
+                "timelineColor": null,
+                "timelineHoverAnimation": 3 / 60.0,
+                "infoDotFillColor": 'rgb(92,92,92)',
+                "fallbackImageUri": '/images/Temp-Thumbnail2.png',
+                "timelineGradientFillStyle": null
             };
 
-            var themeSettings = themeData[theme];
-            $('#vc').css('background-image', themeSettings.background);
+            if (theme && theme.backgroundUrl)
+                this.theme.backgroundUrl = theme.backgroundUrl;
+
+            var themeSettings = this.theme;
+            $('#vc').css('background-image', "url('" + themeSettings.backgroundUrl + "')");
             $('#vc').css('background-color', themeSettings.backgroundColor);
             CZ.Settings.timelineColor = themeSettings.timelineColor;
             CZ.Settings.timelineHoverAnimation = themeSettings.timelineHoverAnimation;
@@ -2075,7 +2053,7 @@ var CZ;
             elem[0].addEventListener("mousedown", CZ.Common.preventbubble, false);
             elem[0].addEventListener("DOMMouseScroll", CZ.Common.preventbubble, false);
             elem[0].addEventListener("mousewheel", CZ.Common.preventbubble, false);
-            var textElem = $("<div style='position:relative' class='text'></div>");
+            var textElem = $("<div style='position:relative; white-space: pre-line' class='text'></div>");
             textElem.text(text).appendTo(elem);
 
             this.initializeContent(elem[0]);
@@ -12065,11 +12043,11 @@ var CZ;
 (function (CZ) {
     (function (Media) {
         var BingMediaPicker = (function () {
-            function BingMediaPicker(container, context) {
+            function BingMediaPicker(container, context, formHost) {
                 this.container = container;
                 this.contentItem = context;
 
-                this.editContentItemForm = CZ.HomePageViewModel.getFormById("#auth-edit-contentitem-form");
+                this.editContentItemForm = formHost ? formHost : CZ.HomePageViewModel.getFormById("#auth-edit-contentitem-form");
                 this.searchTextbox = this.container.find(".cz-bing-search-input");
                 this.mediaTypeRadioButtons = this.container.find(":radio");
                 this.progressBar = this.container.find(".cz-form-progress-bar");
@@ -12078,9 +12056,9 @@ var CZ;
 
                 this.initialize();
             }
-            BingMediaPicker.setup = function (context) {
+            BingMediaPicker.setup = function (context, formHost) {
                 var mediaPickerContainer = CZ.Media.mediaPickersViews["bing"];
-                var mediaPicker = new BingMediaPicker(mediaPickerContainer, context);
+                var mediaPicker = new BingMediaPicker(mediaPickerContainer, context, formHost);
                 var formContainer = $(".cz-form-bing-mediapicker");
 
                 if (formContainer.length === 0) {
@@ -12525,9 +12503,9 @@ var CZ;
             SkyDriveMediaPicker.helperText;
             var mediaType;
 
-            function setup(context) {
+            function setup(context, formHost) {
                 contentItem = context;
-                editContentItemForm = CZ.HomePageViewModel.getFormById("#auth-edit-contentitem-form");
+                editContentItemForm = formHost ? formHost : CZ.HomePageViewModel.getFormById("#auth-edit-contentitem-form");
 
                 SkyDriveMediaPicker.logoutButton = $("<button></button>", {
                     text: "Logout",
@@ -12731,10 +12709,11 @@ var CZ;
 (function (CZ) {
     (function (UI) {
         var MediaList = (function () {
-            function MediaList(container, mediaPickers, context) {
+            function MediaList(container, mediaPickers, context, form) {
                 this.container = container;
                 this.mediaPickers = mediaPickers;
                 this.context = context;
+                this.form = form;
 
                 this.container.addClass("cz-medialist");
                 this.fillListOfLinks();
@@ -12768,7 +12747,7 @@ var CZ;
                 });
 
                 container.click(function (event) {
-                    mp.setup(_this.context);
+                    mp.setup(_this.context, _this.form);
                 });
 
                 container.append(icon);
@@ -13420,7 +13399,7 @@ var CZ;
             }
             FormEditCI.prototype.initUI = function () {
                 var _this = this;
-                this.mediaList = new CZ.UI.MediaList(this.mediaListContainer, CZ.Media.mediaPickers, this.contentItem);
+                this.mediaList = new CZ.UI.MediaList(this.mediaListContainer, CZ.Media.mediaPickers, this.contentItem, this);
                 var that = this;
                 this.saveButton.prop('disabled', false);
 
@@ -13624,6 +13603,97 @@ var CZ;
             return FormEditCI;
         })(CZ.UI.FormUpdateEntity);
         UI.FormEditCI = FormEditCI;
+    })(CZ.UI || (CZ.UI = {}));
+    var UI = CZ.UI;
+})(CZ || (CZ = {}));
+var CZ;
+(function (CZ) {
+    (function (UI) {
+        var FormEditCollection = (function (_super) {
+            __extends(FormEditCollection, _super);
+            function FormEditCollection(container, formInfo) {
+                var _this = this;
+                _super.call(this, container, formInfo);
+                this.contentItem = {};
+
+                this.saveButton = container.find(formInfo.saveButton);
+                this.backgroundInput = container.find(formInfo.backgroundInput);
+                this.collectionTheme = formInfo.collectionTheme;
+                this.activeCollectionTheme = formInfo.collectionTheme;
+                this.mediaListContainer = container.find(formInfo.mediaListContainer);
+
+                this.backgroundInput.on('input', function () {
+                    _this.updateCollectionTheme();
+                });
+
+                this.saveButton.off();
+
+                this.backgroundInput.focus(function () {
+                    _this.backgroundInput.hideError();
+                });
+
+                this.initialize();
+            }
+            FormEditCollection.prototype.initialize = function () {
+                var _this = this;
+                this.saveButton.prop('disabled', false);
+
+                this.backgroundInput.val(this.collectionTheme.backgroundUrl);
+                this.mediaList = new CZ.UI.MediaList(this.mediaListContainer, CZ.Media.mediaPickers, this.contentItem, this);
+
+                this.saveButton.click(function (event) {
+                    _this.updateCollectionTheme();
+                    _this.activeCollectionTheme = _this.collectionTheme;
+
+                    var themeData = {
+                        theme: JSON.stringify(_this.collectionTheme)
+                    };
+
+                    CZ.Service.putCollection(CZ.Service.superCollectionName, CZ.Service.collectionName, themeData).always(function () {
+                        _this.saveButton.prop('disabled', false);
+                        _this.close();
+                    });
+                });
+            };
+
+            FormEditCollection.prototype.updateCollectionTheme = function () {
+                this.collectionTheme.backgroundUrl = this.backgroundInput.val();
+
+                CZ.Settings.applyTheme(this.collectionTheme, false);
+            };
+
+            FormEditCollection.prototype.updateMediaInfo = function () {
+                this.backgroundInput.val(this.contentItem.uri || "");
+                this.updateCollectionTheme();
+            };
+
+            FormEditCollection.prototype.show = function () {
+                _super.prototype.show.call(this, {
+                    effect: "slide",
+                    direction: "left",
+                    duration: 500
+                });
+
+                this.activationSource.addClass("active");
+            };
+
+            FormEditCollection.prototype.close = function () {
+                var _this = this;
+                _super.prototype.close.call(this, {
+                    effect: "slide",
+                    direction: "left",
+                    duration: 500,
+                    complete: function () {
+                        _this.backgroundInput.hideError();
+                        _this.mediaList.remove();
+                    }
+                });
+
+                CZ.Settings.applyTheme(this.activeCollectionTheme, false);
+            };
+            return FormEditCollection;
+        })(CZ.UI.FormUpdateEntity);
+        UI.FormEditCollection = FormEditCollection;
     })(CZ.UI || (CZ.UI = {}));
     var UI = CZ.UI;
 })(CZ || (CZ = {}));
@@ -15084,7 +15154,7 @@ var CZ;
             CZ.StartPage.TwitterLayout(CZ.StartPage.tileLayout, 2);
 
             var hash = CZ.UrlNav.getURL().hash;
-            if (!hash.path || hash.path === "/t" + CZ.Settings.guidEmpty && !hash.params) {
+            if ((!hash.path || hash.path === "/t" + CZ.Settings.guidEmpty && !hash.params) && !CZ.Service.superCollectionName) {
                 show();
             }
         }
@@ -15237,7 +15307,8 @@ var CZ;
             "#header-session-expired-form": "/ui/header-session-expired-form.html",
             "#tour-caption-form": "/ui/tour-caption-form.html",
             "#mediapicker-form": "/ui/mediapicker-form.html",
-            "#start-page": "/ui/start-page.html"
+            "#start-page": "/ui/start-page.html",
+            "#auth-edit-collection-form": "/ui/auth-edit-collection-form.html"
         };
 
         (function (FeatureActivation) {
@@ -15302,10 +15373,6 @@ var CZ;
                 JQueryReference: ".header-breadcrumbs"
             },
             {
-                Name: "Themes",
-                Activation: 4 /* NotProduction */
-            },
-            {
                 Name: "Skydrive",
                 Activation: 0 /* Enabled */
             },
@@ -15313,6 +15380,10 @@ var CZ;
                 Name: "StartPage",
                 Activation: 0 /* Enabled */,
                 JQueryReference: ".header-icon.home-icon"
+            },
+            {
+                Name: "CollectionsAuthoring",
+                Activation: 4 /* NotProduction */
             }
         ];
 
@@ -15496,6 +15567,21 @@ var CZ;
                     }
                 });
 
+                $("#editCollectionButton").click(function () {
+                    closeAllForms();
+                    var form = new CZ.UI.FormEditCollection(forms[19], {
+                        activationSource: $(".header-icon.edit-icon"),
+                        navButton: ".cz-form-nav",
+                        closeButton: ".cz-form-close-btn > .cz-form-btn",
+                        titleTextblock: ".cz-form-title",
+                        saveButton: ".cz-form-save",
+                        collectionTheme: CZ.Settings.theme,
+                        backgroundInput: $(".cz-form-collection-background"),
+                        mediaListContainer: ".cz-form-medialist"
+                    });
+                    form.show();
+                });
+
                 CZ.Authoring.initialize(CZ.Common.vc, {
                     showMessageWindow: function (message, title, onClose) {
                         var wnd = new CZ.UI.MessageWindow(forms[13], message, title);
@@ -15674,6 +15760,10 @@ var CZ;
                         $("#MyTimelinesBlock").attr("data-toggle", "show");
                     }
 
+                    if (CZ.Authoring.isEnabled && IsFeatureEnabled(_featureMap, "CollectionsAuthoring")) {
+                        $("#editCollectionButton").show();
+                    }
+
                     CZ.Common.loadData().then(function (response) {
                         if (!response) {
                             if (CZ.Authoring.isEnabled) {
@@ -15776,13 +15866,19 @@ var CZ;
                 CZ.Settings.signinUrlYahoo = response.signinUrlYahoo;
             });
 
-            CZ.Settings.applyTheme(null);
+            CZ.Settings.applyTheme(null, CZ.Service.superCollectionName != null);
 
             if (CZ.Service.superCollectionName) {
                 CZ.Service.getCollections(CZ.Service.superCollectionName).then(function (response) {
                     $(response).each(function (index) {
                         if (response[index] && response[index].Title.toLowerCase() === CZ.Service.collectionName.toLowerCase()) {
-                            CZ.Settings.applyTheme(response[index].theme);
+                            var themeData = null;
+                            try  {
+                                themeData = JSON.parse(response[index].theme);
+                            } catch (e) {
+                            }
+
+                            CZ.Settings.applyTheme(themeData, false);
                         }
                     });
                 });

--- a/Source/Chronozoom.UI/scripts/cz.js
+++ b/Source/Chronozoom.UI/scripts/cz.js
@@ -26,7 +26,8 @@ var CZ;
             "#header-session-expired-form": "/ui/header-session-expired-form.html",
             "#tour-caption-form": "/ui/tour-caption-form.html",
             "#mediapicker-form": "/ui/mediapicker-form.html",
-            "#start-page": "/ui/start-page.html"
+            "#start-page": "/ui/start-page.html",
+            "#auth-edit-collection-form": "/ui/auth-edit-collection-form.html"
         };
 
         (function (FeatureActivation) {
@@ -91,10 +92,6 @@ var CZ;
                 JQueryReference: ".header-breadcrumbs"
             },
             {
-                Name: "Themes",
-                Activation: 4 /* NotProduction */
-            },
-            {
                 Name: "Skydrive",
                 Activation: 0 /* Enabled */
             },
@@ -102,6 +99,10 @@ var CZ;
                 Name: "StartPage",
                 Activation: 0 /* Enabled */,
                 JQueryReference: ".header-icon.home-icon"
+            },
+            {
+                Name: "CollectionsAuthoring",
+                Activation: 0 /* Enabled */
             }
         ];
 
@@ -285,6 +286,21 @@ var CZ;
                     }
                 });
 
+                $("#editCollectionButton").click(function () {
+                    closeAllForms();
+                    var form = new CZ.UI.FormEditCollection(forms[19], {
+                        activationSource: $(".header-icon.edit-icon"),
+                        navButton: ".cz-form-nav",
+                        closeButton: ".cz-form-close-btn > .cz-form-btn",
+                        titleTextblock: ".cz-form-title",
+                        saveButton: ".cz-form-save",
+                        collectionTheme: CZ.Settings.theme,
+                        backgroundInput: $(".cz-form-collection-background"),
+                        mediaListContainer: ".cz-form-medialist"
+                    });
+                    form.show();
+                });
+
                 CZ.Authoring.initialize(CZ.Common.vc, {
                     showMessageWindow: function (message, title, onClose) {
                         var wnd = new CZ.UI.MessageWindow(forms[13], message, title);
@@ -463,6 +479,10 @@ var CZ;
                         $("#MyTimelinesBlock").attr("data-toggle", "show");
                     }
 
+                    if (CZ.Authoring.isEnabled && IsFeatureEnabled(_featureMap, "CollectionsAuthoring")) {
+                        $("#editCollectionButton").show();
+                    }
+
                     CZ.Common.loadData().then(function (response) {
                         if (!response) {
                             if (CZ.Authoring.isEnabled) {
@@ -565,13 +585,19 @@ var CZ;
                 CZ.Settings.signinUrlYahoo = response.signinUrlYahoo;
             });
 
-            CZ.Settings.applyTheme(null);
+            CZ.Settings.applyTheme(null, CZ.Service.superCollectionName != null);
 
             if (CZ.Service.superCollectionName) {
                 CZ.Service.getCollections(CZ.Service.superCollectionName).then(function (response) {
                     $(response).each(function (index) {
                         if (response[index] && response[index].Title.toLowerCase() === CZ.Service.collectionName.toLowerCase()) {
-                            CZ.Settings.applyTheme(response[index].theme);
+                            var themeData = null;
+                            try  {
+                                themeData = JSON.parse(response[index].theme);
+                            } catch (e) {
+                            }
+
+                            CZ.Settings.applyTheme(themeData, false);
                         }
                     });
                 });

--- a/Source/Chronozoom.UI/scripts/settings.js
+++ b/Source/Chronozoom.UI/scripts/settings.js
@@ -165,44 +165,22 @@
         }());
 
         Settings.theme;
-        function applyTheme(theme) {
-            if (!theme) {
-                theme = "cosmos";
-            }
-
-            this.theme = theme;
-            var themeData = {
-                "cosmos": {
-                    "background": "url('/images/background.jpg')",
-                    "backgroundColor": "#232323",
-                    "timelineColor": null,
-                    "timelineHoverAnimation": 3 / 60.0,
-                    "infoDotFillColor": 'rgb(92,92,92)',
-                    "fallbackImageUri": '/images/Temp-Thumbnail2.png',
-                    "timelineGradientFillStyle": null
-                },
-                "gray": {
-                    "background": "none",
-                    "backgroundColor": "#bebebe",
-                    "timelineColor": null,
-                    "timelineHoverAnimation": 3 / 60.0,
-                    "infoDotFillColor": 'rgb(92,92,92)',
-                    "fallbackImageUri": '/images/Temp-Thumbnail2.png',
-                    "timelineGradientFillStyle": "#9e9e9e"
-                },
-                "aqua": {
-                    "background": "none",
-                    "backgroundColor": "rgb(238, 238, 238)",
-                    "timelineColor": "rgba(52, 76, 130, 0.5)",
-                    "timelineHoverAnimation": 3 / 60.0,
-                    "infoDotFillColor": 'rgb(55,84,123)',
-                    "fallbackImageUri": '/images/Temp-Thumbnail-Aqua.png',
-                    "timelineGradientFillStyle": "rgb(80,123,175)"
-                }
+        function applyTheme(theme, delayLoad) {
+            this.theme = {
+                "backgroundUrl": delayLoad ? "" : "/images/background.jpg",
+                "backgroundColor": "#232323",
+                "timelineColor": null,
+                "timelineHoverAnimation": 3 / 60.0,
+                "infoDotFillColor": 'rgb(92,92,92)',
+                "fallbackImageUri": '/images/Temp-Thumbnail2.png',
+                "timelineGradientFillStyle": null
             };
 
-            var themeSettings = themeData[theme];
-            $('#vc').css('background-image', themeSettings.background);
+            if (theme && theme.backgroundUrl)
+                this.theme.backgroundUrl = theme.backgroundUrl;
+
+            var themeSettings = this.theme;
+            $('#vc').css('background-image', "url('" + themeSettings.backgroundUrl + "')");
             $('#vc').css('background-color', themeSettings.backgroundColor);
             CZ.Settings.timelineColor = themeSettings.timelineColor;
             CZ.Settings.timelineHoverAnimation = themeSettings.timelineHoverAnimation;

--- a/Source/Chronozoom.UI/scripts/settings.ts
+++ b/Source/Chronozoom.UI/scripts/settings.ts
@@ -2,6 +2,16 @@
 
 module CZ {
     export module Settings {
+		export interface ICollectionTheme {
+			backgroundUrl: string;
+			backgroundColor: string;
+            timelineColor: string;
+            timelineHoverAnimation: number;
+            infoDotFillColor: string;
+            fallbackImageUri: string;
+            timelineGradientFillStyle: string;
+        }
+
         export var isAuthorized = false; // user is authorized flag
         export var userSuperCollectionName = "";
         export var userCollectionName = "";
@@ -182,45 +192,22 @@ module CZ {
         }());
 
         // Theme constants
-        export var theme;
-        export function applyTheme(theme: string) {
-            if (!theme) {
-                theme = "cosmos";
-            }
+        export var theme: ICollectionTheme;
+        export function applyTheme(theme: ICollectionTheme, delayLoad: boolean) {
+			this.theme = {
+                "backgroundUrl": delayLoad ? "" : "/images/background.jpg",
+                "backgroundColor": "#232323",
+                "timelineColor": null,
+                "timelineHoverAnimation": 3 / 60.0,
+                "infoDotFillColor": 'rgb(92,92,92)',
+                "fallbackImageUri": '/images/Temp-Thumbnail2.png',
+                "timelineGradientFillStyle": null
+            };
 
-            this.theme = theme;
-            var themeData = {
-                "cosmos": {
-                    "background": "url('/images/background.jpg')",
-                    "backgroundColor": "#232323",
-                    "timelineColor": null,
-                    "timelineHoverAnimation": 3 / 60.0,
-                    "infoDotFillColor": 'rgb(92,92,92)',
-                    "fallbackImageUri": '/images/Temp-Thumbnail2.png',
-                    "timelineGradientFillStyle": null
-                },
-                "gray": {
-                    "background": "none",
-                    "backgroundColor": "#bebebe",
-                    "timelineColor": null,
-                    "timelineHoverAnimation": 3 / 60.0,
-                    "infoDotFillColor": 'rgb(92,92,92)',
-                    "fallbackImageUri": '/images/Temp-Thumbnail2.png',
-                    "timelineGradientFillStyle": "#9e9e9e"
-                },
-                "aqua": {
-                    "background": "none",
-                    "backgroundColor": "rgb(238, 238, 238)",
-                    "timelineColor": "rgba(52, 76, 130, 0.5)",
-                    "timelineHoverAnimation": 3 / 60.0,
-                    "infoDotFillColor": 'rgb(55,84,123)',
-                    "fallbackImageUri": '/images/Temp-Thumbnail-Aqua.png',
-                    "timelineGradientFillStyle": "rgb(80,123,175)"
-                }
-            }
+            if (theme && theme.backgroundUrl) this.theme.backgroundUrl = theme.backgroundUrl;
 
-            var themeSettings = themeData[theme];
-            $('#vc').css('background-image', themeSettings.background);
+            var themeSettings = this.theme;
+            $('#vc').css('background-image', "url('" + themeSettings.backgroundUrl + "')");
             $('#vc').css('background-color', themeSettings.backgroundColor);
             CZ.Settings.timelineColor = themeSettings.timelineColor;
             CZ.Settings.timelineHoverAnimation = themeSettings.timelineHoverAnimation;

--- a/Source/Chronozoom.UI/scripts/vccontent.js
+++ b/Source/Chronozoom.UI/scripts/vccontent.js
@@ -1261,7 +1261,7 @@ var CZ;
             elem[0].addEventListener("mousedown", CZ.Common.preventbubble, false);
             elem[0].addEventListener("DOMMouseScroll", CZ.Common.preventbubble, false);
             elem[0].addEventListener("mousewheel", CZ.Common.preventbubble, false);
-            var textElem = $("<div style='position:relative' class='text'></div>");
+            var textElem = $("<div style='position:relative; white-space: pre-line' class='text'></div>");
             textElem.text(text).appendTo(elem);
 
             this.initializeContent(elem[0]);

--- a/Source/Chronozoom.UI/scripts/vccontent.ts
+++ b/Source/Chronozoom.UI/scripts/vccontent.ts
@@ -1666,7 +1666,7 @@ module CZ {
             elem[0].addEventListener("mousedown", CZ.Common.preventbubble, false);
             elem[0].addEventListener("DOMMouseScroll", CZ.Common.preventbubble, false);
             elem[0].addEventListener("mousewheel", CZ.Common.preventbubble, false);
-            var textElem = $("<div style='position:relative' class='text'></div>");
+            var textElem = $("<div style='position:relative; white-space: pre-line' class='text'></div>");
             textElem.text(text).appendTo(elem);
 
             //Initialize content

--- a/Source/Chronozoom.UI/ui/auth-edit-collection-form.html
+++ b/Source/Chronozoom.UI/ui/auth-edit-collection-form.html
@@ -1,0 +1,25 @@
+﻿<div class="cz-form-header">
+    <ul>
+        <li class="cz-form-nav">
+            &lt;
+        </li>
+        <li class="cz-form-title">
+            Edit Collection
+        </li>
+        <li class="cz-form-close-btn">
+            <a class="cz-form-btn">
+                X
+            </a>
+        </li>
+    </ul>
+</div>
+<div class="cz-form-content">
+    <label class="cz-lightgray cz-form-label">Import from:</label>
+    <div class="cz-form-medialist"></div>
+    <br />
+    <label class="cz-lightgray cz-form-label">URL of background image:</label>
+    <input class="cz-form-collection-background cz-input" style="display: block; width: 100%;" type="text" />
+
+    <br />
+    <button class="cz-form-save cz-button" style="display: inline-block; margin-right:30px;">save collection</button>
+</div>

--- a/Source/Chronozoom.UI/ui/auth-edit-collection-form.ts
+++ b/Source/Chronozoom.UI/ui/auth-edit-collection-form.ts
@@ -1,0 +1,105 @@
+/// <reference path='../ui/controls/formbase.ts'/>
+/// <reference path='../scripts/authoring.ts'/>
+/// <reference path='../scripts/settings.ts'/>
+/// <reference path='../scripts/typings/jquery/jquery.d.ts'/>
+/// <reference path='../scripts/media.ts'/>
+/// <reference path='../ui/media/skydrive-mediapicker.ts'/>
+
+module CZ {
+    export module UI {
+        export interface IFormEditCollectionInfo extends CZ.UI.IFormUpdateEntityInfo {
+			backgroundInput: JQuery;
+            collectionTheme: CZ.Settings.ICollectionTheme;
+			mediaListContainer: string;
+        }
+
+        export class FormEditCollection extends CZ.UI.FormUpdateEntity {
+            public saveButton: JQuery;
+            private backgroundInput: JQuery;
+            public collectionTheme: CZ.Settings.ICollectionTheme;
+            public activeCollectionTheme: CZ.Settings.ICollectionTheme;
+			private mediaListContainer: JQuery;
+            private mediaList: CZ.UI.MediaList;
+            private contentItem: any = {};
+
+            // We only need to add additional initialization in constructor.
+            constructor(container: JQuery, formInfo: IFormEditCollectionInfo) {
+                super(container, formInfo);
+				
+                this.saveButton = container.find(formInfo.saveButton);
+                this.backgroundInput = container.find(formInfo.backgroundInput);
+                this.collectionTheme = formInfo.collectionTheme;
+                this.activeCollectionTheme = formInfo.collectionTheme;
+				this.mediaListContainer = container.find(formInfo.mediaListContainer);
+
+				this.backgroundInput.on('input', () => {
+                    this.updateCollectionTheme();
+				});
+
+                this.saveButton.off();
+
+                this.backgroundInput.focus(() => {
+                    this.backgroundInput.hideError();
+                });
+
+                this.initialize();
+            }
+
+            private initialize(): void {
+                this.saveButton.prop('disabled', false);
+
+                this.backgroundInput.val(this.collectionTheme.backgroundUrl);
+                this.mediaList = new CZ.UI.MediaList(this.mediaListContainer, CZ.Media.mediaPickers, this.contentItem, this);
+
+                this.saveButton.click(event => {
+                    this.updateCollectionTheme();
+                    this.activeCollectionTheme = this.collectionTheme;
+
+                    var themeData = {
+                        theme: JSON.stringify(this.collectionTheme)
+                    };
+
+                    CZ.Service.putCollection(CZ.Service.superCollectionName, CZ.Service.collectionName, themeData).always(() => {
+						this.saveButton.prop('disabled', false);
+						this.close();
+					})
+                });
+            }
+
+            private updateCollectionTheme() {
+                this.collectionTheme.backgroundUrl = this.backgroundInput.val();
+
+                CZ.Settings.applyTheme(this.collectionTheme, false);
+            }
+
+            public updateMediaInfo() {
+                this.backgroundInput.val(this.contentItem.uri || "");
+                this.updateCollectionTheme();
+            }
+
+            public show(): void {
+                super.show({
+                    effect: "slide",
+                    direction: "left",
+                    duration: 500
+                });
+
+                this.activationSource.addClass("active");
+            }
+
+            public close() {
+                super.close({
+                    effect: "slide",
+                    direction: "left",
+                    duration: 500,
+                    complete: () => {
+                        this.backgroundInput.hideError();
+						this.mediaList.remove();
+                    }
+                });
+
+                CZ.Settings.applyTheme(this.activeCollectionTheme, false);
+            }
+        }
+    }
+}

--- a/Source/Chronozoom.UI/ui/auth-edit-contentitem-form.js
+++ b/Source/Chronozoom.UI/ui/auth-edit-contentitem-form.js
@@ -48,7 +48,7 @@ var CZ;
             }
             FormEditCI.prototype.initUI = function () {
                 var _this = this;
-                this.mediaList = new CZ.UI.MediaList(this.mediaListContainer, CZ.Media.mediaPickers, this.contentItem);
+                this.mediaList = new CZ.UI.MediaList(this.mediaListContainer, CZ.Media.mediaPickers, this.contentItem, this);
                 var that = this;
                 this.saveButton.prop('disabled', false);
 

--- a/Source/Chronozoom.UI/ui/auth-edit-contentitem-form.ts
+++ b/Source/Chronozoom.UI/ui/auth-edit-contentitem-form.ts
@@ -1,6 +1,7 @@
 /// <reference path='../ui/controls/formbase.ts'/>
 /// <reference path='../scripts/authoring.ts'/>
 /// <reference path='../scripts/typings/jquery/jquery.d.ts'/>
+/// <reference path='../scripts/media.ts'/>
 /// <reference path='../ui/media/skydrive-mediapicker.ts'/>
 
 module CZ {
@@ -80,7 +81,7 @@ module CZ {
             }
 
             private initUI() {
-                this.mediaList = new CZ.UI.MediaList(this.mediaListContainer, CZ.Media.mediaPickers, this.contentItem);
+                this.mediaList = new CZ.UI.MediaList(this.mediaListContainer, CZ.Media.mediaPickers, this.contentItem, this);
                 var that = this;
                 this.saveButton.prop('disabled', false);
 

--- a/Source/Chronozoom.UI/ui/controls/medialist.js
+++ b/Source/Chronozoom.UI/ui/controls/medialist.js
@@ -2,10 +2,11 @@ var CZ;
 (function (CZ) {
     (function (UI) {
         var MediaList = (function () {
-            function MediaList(container, mediaPickers, context) {
+            function MediaList(container, mediaPickers, context, form) {
                 this.container = container;
                 this.mediaPickers = mediaPickers;
                 this.context = context;
+                this.form = form;
 
                 this.container.addClass("cz-medialist");
                 this.fillListOfLinks();
@@ -39,7 +40,7 @@ var CZ;
                 });
 
                 container.click(function (event) {
-                    mp.setup(_this.context);
+                    mp.setup(_this.context, _this.form);
                 });
 
                 container.append(icon);

--- a/Source/Chronozoom.UI/ui/controls/medialist.ts
+++ b/Source/Chronozoom.UI/ui/controls/medialist.ts
@@ -8,11 +8,13 @@ module CZ {
             private mediaPickers: any;
             private container: JQuery;
             private context: any;
+            private form: any;
 
-            constructor(container: JQuery, mediaPickers: any, context: any) {
+            constructor(container: JQuery, mediaPickers: any, context: any, form: any) {
                 this.container = container;
                 this.mediaPickers = mediaPickers;
                 this.context = context;
+                this.form = form;
 
                 this.container.addClass("cz-medialist");
                 this.fillListOfLinks();
@@ -47,7 +49,7 @@ module CZ {
                 });
 
                 container.click(event => {
-                    mp.setup(this.context);
+                    mp.setup(this.context, this.form);
                 });
 
                 container.append(icon);

--- a/Source/Chronozoom.UI/ui/media/bing-mediapicker.js
+++ b/Source/Chronozoom.UI/ui/media/bing-mediapicker.js
@@ -2,11 +2,11 @@ var CZ;
 (function (CZ) {
     (function (Media) {
         var BingMediaPicker = (function () {
-            function BingMediaPicker(container, context) {
+            function BingMediaPicker(container, context, formHost) {
                 this.container = container;
                 this.contentItem = context;
 
-                this.editContentItemForm = CZ.HomePageViewModel.getFormById("#auth-edit-contentitem-form");
+                this.editContentItemForm = formHost ? formHost : CZ.HomePageViewModel.getFormById("#auth-edit-contentitem-form");
                 this.searchTextbox = this.container.find(".cz-bing-search-input");
                 this.mediaTypeRadioButtons = this.container.find(":radio");
                 this.progressBar = this.container.find(".cz-form-progress-bar");
@@ -15,9 +15,9 @@ var CZ;
 
                 this.initialize();
             }
-            BingMediaPicker.setup = function (context) {
+            BingMediaPicker.setup = function (context, formHost) {
                 var mediaPickerContainer = CZ.Media.mediaPickersViews["bing"];
-                var mediaPicker = new BingMediaPicker(mediaPickerContainer, context);
+                var mediaPicker = new BingMediaPicker(mediaPickerContainer, context, formHost);
                 var formContainer = $(".cz-form-bing-mediapicker");
 
                 if (formContainer.length === 0) {

--- a/Source/Chronozoom.UI/ui/media/bing-mediapicker.ts
+++ b/Source/Chronozoom.UI/ui/media/bing-mediapicker.ts
@@ -6,9 +6,9 @@
 module CZ {
     export module Media {
         export class BingMediaPicker {
-            public static setup(context: any) {
+            public static setup(context: any, formHost: any) {
                 var mediaPickerContainer = CZ.Media.mediaPickersViews["bing"];
-                var mediaPicker = new BingMediaPicker(mediaPickerContainer, context);
+                var mediaPicker = new BingMediaPicker(mediaPickerContainer, context, formHost);
                 var formContainer = $(".cz-form-bing-mediapicker");
 
                 // Create container for Media Picker's form if it doesn't exist.
@@ -54,7 +54,7 @@ module CZ {
                 form.show();
             }
 
-            private editContentItemForm: CZ.UI.FormEditCI;
+            private editContentItemForm: any;
             private container: JQuery;
             private contentItem: any;
 
@@ -64,11 +64,11 @@ module CZ {
             private searchButton: JQuery;
             public searchTextbox: JQuery;
 
-            constructor(container: JQuery, context: any) {
+            constructor(container: JQuery, context: any, formHost: any) {
                 this.container = container;
                 this.contentItem = context;
 
-                this.editContentItemForm = CZ.HomePageViewModel.getFormById("#auth-edit-contentitem-form");
+                this.editContentItemForm = formHost ? formHost : CZ.HomePageViewModel.getFormById("#auth-edit-contentitem-form");
                 this.searchTextbox = this.container.find(".cz-bing-search-input");
                 this.mediaTypeRadioButtons = this.container.find(":radio");
                 this.progressBar = this.container.find(".cz-form-progress-bar");

--- a/Source/Chronozoom.UI/ui/media/skydrive-mediapicker.js
+++ b/Source/Chronozoom.UI/ui/media/skydrive-mediapicker.js
@@ -11,9 +11,9 @@
             SkyDriveMediaPicker.helperText;
             var mediaType;
 
-            function setup(context) {
+            function setup(context, formHost) {
                 contentItem = context;
-                editContentItemForm = CZ.HomePageViewModel.getFormById("#auth-edit-contentitem-form");
+                editContentItemForm = formHost ? formHost : CZ.HomePageViewModel.getFormById("#auth-edit-contentitem-form");
 
                 SkyDriveMediaPicker.logoutButton = $("<button></button>", {
                     text: "Logout",

--- a/Source/Chronozoom.UI/ui/media/skydrive-mediapicker.ts
+++ b/Source/Chronozoom.UI/ui/media/skydrive-mediapicker.ts
@@ -9,7 +9,7 @@ module CZ {
         declare var WL: any;
 
         export module SkyDriveMediaPicker {
-            var editContentItemForm: CZ.UI.FormEditCI;
+            var editContentItemForm: any;
             var contentItem: any;
             export var filePicker: any;
             export var filePickerIframe: JQuery;
@@ -18,9 +18,9 @@ module CZ {
             export var helperText: JQuery;
             var mediaType: string;
 
-            export function setup(context: any) {
+            export function setup(context: any, formHost: any) {
                 contentItem = context;
-                editContentItemForm = CZ.HomePageViewModel.getFormById("#auth-edit-contentitem-form");
+                editContentItemForm = formHost ? formHost : CZ.HomePageViewModel.getFormById("#auth-edit-contentitem-form");
 
                 logoutButton = $("<button></button>", {
                     text: "Logout",

--- a/Source/Chronozoom.UI/ui/start-page.js
+++ b/Source/Chronozoom.UI/ui/start-page.js
@@ -670,7 +670,7 @@ var CZ;
             CZ.StartPage.TwitterLayout(CZ.StartPage.tileLayout, 2);
 
             var hash = CZ.UrlNav.getURL().hash;
-            if (!hash.path || hash.path === "/t" + CZ.Settings.guidEmpty && !hash.params) {
+            if ((!hash.path || hash.path === "/t" + CZ.Settings.guidEmpty && !hash.params) && !CZ.Service.superCollectionName) {
                 show();
             }
         }

--- a/Source/Chronozoom.UI/ui/start-page.ts
+++ b/Source/Chronozoom.UI/ui/start-page.ts
@@ -756,9 +756,9 @@ module CZ {
             CZ.StartPage.cloneTweetTemplate("#template-tweet .box", CZ.StartPage.tileLayout, 2); /* Tweeted Timelines */
             CZ.StartPage.TwitterLayout(CZ.StartPage.tileLayout, 2);
 
-            // Show home page if this is a root URL of ChronoZoom.
+            // Show home page if this is a root URL of ChronoZoom and if this is not a custom collection
             var hash = CZ.UrlNav.getURL().hash;
-            if (!hash.path || hash.path === "/t" + CZ.Settings.guidEmpty && !hash.params) {
+            if ((!hash.path || hash.path === "/t" + CZ.Settings.guidEmpty && !hash.params) && !CZ.Service.superCollectionName) {
                 show();
             }
         }


### PR DESCRIPTION
Adds support to edit collections. This initial check-in adds support to change the background image, a subsequent check-in will add more functionality. See discussion here: https://github.com/alterm4nn/ChronoZoom/issues/1235

Additionally, this change:
- Adds support for line breaks in the description field (user ask)
- Navigates directly to the timeline for collection pages (user ask)

![modifycollectionbackground](https://f.cloud.github.com/assets/3478847/2027562/9619ae4e-88b8-11e3-87c0-1e763c7fc34b.png)
