### PR TITLE
More robust generation of timeline shortcuts. NULL user is allowed for t...

### DIFF
--- a/Source/Chronozoom.Entities/Collection.cs
+++ b/Source/Chronozoom.Entities/Collection.cs
@@ -45,5 +45,9 @@ namespace Chronozoom.Entities
         /// </summary>
         [DataMember(Name="theme")]
         public string Theme { get; set; }
+
+        /// <summary>SuperCollection for this collection</summary>
+        [DataMember]
+        public SuperCollection SuperCollection { get; set; }
     }
 }

--- a/Source/Chronozoom.Entities/Triples.cs
+++ b/Source/Chronozoom.Entities/Triples.cs
@@ -267,8 +267,8 @@ namespace Chronozoom.Entities
             }
             else
             {
-                ts.TimelineUrl = String.Format("/{0}/{1}/#{2}", timeline.Collection.User.DisplayName, timeline.Collection.Title, GetContentPath(timeline.Collection.Id, timeline.Id, null));
-                ts.Author = timeline.Collection.User.DisplayName;
+                ts.TimelineUrl = String.Format("/{0}/{1}/#{2}", timeline.Collection.SuperCollection.Title, timeline.Collection.Title, GetContentPath(timeline.Collection.Id, timeline.Id, null));
+                ts.Author = timeline.Collection.User != null ? timeline.Collection.User.DisplayName : ""; 
             }
             ts.ImageUrl = GetTimelineImageUrl(timeline);
             return ts;

--- a/Source/Chronozoom.UI/api/Favorites.svc.cs
+++ b/Source/Chronozoom.UI/api/Favorites.svc.cs
@@ -42,6 +42,7 @@ namespace Chronozoom.UI
                         var timeline = storage.Timelines.Where(x => x.Id == g)
                             .Include("Collection")
                             .Include("Collection.User")
+                            .Include("Collection.SuperCollection")
                             .Include("Exhibits")
                             .Include("Exhibits.ContentItems")
                             .FirstOrDefault();

--- a/Source/Chronozoom.UI/api/Featured.svc.cs
+++ b/Source/Chronozoom.UI/api/Featured.svc.cs
@@ -48,6 +48,7 @@ namespace Chronozoom.UI
                         var timeline = storage.Timelines.Where(x => x.Id == g)
                             .Include("Collection")
                             .Include("Collection.User")
+                            .Include("Collection.SuperCollection")
                             .Include("Exhibits")
                             .Include("Exhibits.ContentItems")
                             .FirstOrDefault();
@@ -75,6 +76,7 @@ namespace Chronozoom.UI
                 {
                     return false;
                 }
+
 
                 var cacheKey = string.Format(CultureInfo.InvariantCulture, "UserFeatured - {0}", user.Id);
                 if (Cache.Contains(cacheKey))


### PR DESCRIPTION
...imelines.

This fix will prevent situations similar to CERN incident. Featured timelines have no dependency on fact that user display name and supercollection name are always the same.
