### PR TITLE
Upgrade type script libraries

### DIFF
--- a/Source/Chronozoom.UI/Chronozoom.UI.csproj
+++ b/Source/Chronozoom.UI/Chronozoom.UI.csproj
@@ -767,18 +767,20 @@
   </ProjectExtensions>
   <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
   <PropertyGroup>
-    <PostBuildEvent>tsc -target ES5 --removeComments --out "$(ProjectDir)cz.js" "$(ProjectDir)scripts\cz.ts" "$(ProjectDir)scripts\plugins\error-plugin.ts"
-      exit 0</PostBuildEvent>
+    <PostBuildEvent>
+    </PostBuildEvent>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
     <TypeScriptTarget>ES5</TypeScriptTarget>
     <TypeScriptRemoveComments>true</TypeScriptRemoveComments>
     <TypeScriptSourceMap>false</TypeScriptSourceMap>
+    <TypeScriptOutFile>cz.js</TypeScriptOutFile>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <TypeScriptTarget>ES5</TypeScriptTarget>
     <TypeScriptRemoveComments>true</TypeScriptRemoveComments>
     <TypeScriptSourceMap>false</TypeScriptSourceMap>
+    <TypeScriptOutFile>cz.js</TypeScriptOutFile>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\TypeScript\Microsoft.TypeScript.targets" Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\TypeScript\Microsoft.TypeScript.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Source/Chronozoom.UI/scripts/cz.ts
+++ b/Source/Chronozoom.UI/scripts/cz.ts
@@ -864,7 +864,11 @@ module CZ {
             });
 
             $(window).bind('resize', function () {
-                timeSeriesChart.updateCanvasHeight();
+
+                if (timeSeriesChart) {
+                    timeSeriesChart.updateCanvasHeight();
+                }
+
                 CZ.Common.updateLayout();
 
                 //updating timeSeries chart

--- a/Source/Chronozoom.UI/scripts/typings/jquery/jquery.d.ts
+++ b/Source/Chronozoom.UI/scripts/typings/jquery/jquery.d.ts
@@ -4,19 +4,19 @@
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 /* *****************************************************************************
- Copyright (c) Microsoft Corporation. All rights reserved.
- Licensed under the Apache License, Version 2.0 (the "License"); you may not use
- this file except in compliance with the License. You may obtain a copy of the
- License at http://www.apache.org/licenses/LICENSE-2.0
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License. You may obtain a copy of the
+License at http://www.apache.org/licenses/LICENSE-2.0
 
- THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED
- WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
- MERCHANTABLITY OR NON-INFRINGEMENT.
+THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED
+WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+MERCHANTABLITY OR NON-INFRINGEMENT.
 
- See the Apache Version 2.0 License for specific language governing permissions
- and limitations under the License.
- ***************************************************************************** */
+See the Apache Version 2.0 License for specific language governing permissions
+and limitations under the License.
+***************************************************************************** */
 
 /**
  * Interface for the AJAX setting that will configure the AJAX request
@@ -25,11 +25,11 @@ interface JQueryAjaxSettings {
     /**
      * The content type sent in the request header that tells the server what kind of response it will accept in return. If the accepts setting needs modification, it is recommended to do so once in the $.ajaxSetup() method.
      */
-        accepts?: any;
+    accepts?: any;
     /**
      * By default, all requests are sent asynchronously (i.e. this is set to true by default). If you need synchronous requests, set this option to false. Cross-domain requests and dataType: "jsonp" requests do not support synchronous operation. Note that synchronous requests may temporarily lock the browser, disabling any actions while the request is active. As of jQuery 1.8, the use of async: false with jqXHR ($.Deferred) is deprecated; you must use the success/error/complete callback options instead of the corresponding methods of the jqXHR object such as jqXHR.done() or the deprecated jqXHR.success().
      */
-        async?: boolean;
+    async?: boolean;
     /**
      * A pre-request callback function that can be used to modify the jqXHR (in jQuery 1.4.x, XMLHTTPRequest) object before it is sent. Use this to set custom headers, etc. The jqXHR and settings objects are passed as arguments. This is an Ajax Event. Returning false in the beforeSend function will cancel the request. As of jQuery 1.5, the beforeSend option will be called regardless of the type of request.
      */
@@ -37,7 +37,7 @@ interface JQueryAjaxSettings {
     /**
      * If set to false, it will force requested pages not to be cached by the browser. Note: Setting cache to false will only work correctly with HEAD and GET requests. It works by appending "_={timestamp}" to the GET parameters. The parameter is not needed for other types of requests, except in IE8 when a POST is made to a URL that has already been requested by a GET.
      */
-        cache?: boolean;
+    cache?: boolean;
     /**
      * A function to be called when the request finishes (after success and error callbacks are executed). The function gets passed two arguments: The jqXHR (in jQuery 1.4.x, XMLHTTPRequest) object and a string categorizing the status of the request ("success", "notmodified", "error", "timeout", "abort", or "parsererror"). As of jQuery 1.5, the complete setting can accept an array of functions. Each function will be called in turn. This is an Ajax Event.
      */
@@ -45,37 +45,37 @@ interface JQueryAjaxSettings {
     /**
      * An object of string/regular-expression pairs that determine how jQuery will parse the response, given its content type. (version added: 1.5)
      */
-        contents?: { [key: string]: any; };
+    contents?: { [key: string]: any; };
     //According to jQuery.ajax source code, ajax's option actually allows contentType to set to "false"
     // https://github.com/borisyankov/DefinitelyTyped/issues/742
     /**
      * When sending data to the server, use this content type. Default is "application/x-www-form-urlencoded; charset=UTF-8", which is fine for most cases. If you explicitly pass in a content-type to $.ajax(), then it is always sent to the server (even if no data is sent). The W3C XMLHttpRequest specification dictates that the charset is always UTF-8; specifying another charset will not force the browser to change the encoding.
      */
-        contentType?: any;
+    contentType?: any;
     /**
      * This object will be made the context of all Ajax-related callbacks. By default, the context is an object that represents the ajax settings used in the call ($.ajaxSettings merged with the settings passed to $.ajax).
      */
-        context?: any;
+    context?: any;
     /**
      * An object containing dataType-to-dataType converters. Each converter's value is a function that returns the transformed value of the response. (version added: 1.5)
      */
-        converters?: { [key: string]: any; };
+    converters?: { [key: string]: any; };
     /**
      * If you wish to force a crossDomain request (such as JSONP) on the same domain, set the value of crossDomain to true. This allows, for example, server-side redirection to another domain. (version added: 1.5)
      */
-        crossDomain?: boolean;
+    crossDomain?: boolean;
     /**
      * Data to be sent to the server. It is converted to a query string, if not already a string. It's appended to the url for GET-requests. See processData option to prevent this automatic processing. Object must be Key/Value pairs. If value is an Array, jQuery serializes multiple values with same key based on the value of the traditional setting (described below).
      */
-        data?: any;
+    data?: any;
     /**
      * A function to be used to handle the raw response data of XMLHttpRequest.This is a pre-filtering function to sanitize the response. You should return the sanitized data. The function accepts two arguments: The raw data returned from the server and the 'dataType' parameter.
      */
     dataFilter? (data: any, ty: any): any;
     /**
-     * The type of data that you're expecting back from the server. If none is specified, jQuery will try to infer it based on the MIME type of the response (an XML MIME type will yield XML, in 1.4 JSON will yield a JavaScript object, in 1.4 script will execute the script, and anything else will be returned as a string).
+     * The type of data that you're expecting back from the server. If none is specified, jQuery will try to infer it based on the MIME type of the response (an XML MIME type will yield XML, in 1.4 JSON will yield a JavaScript object, in 1.4 script will execute the script, and anything else will be returned as a string). 
      */
-        dataType?: string;
+    dataType?: string;
     /**
      * A function to be called if the request fails. The function receives three arguments: The jqXHR (in jQuery 1.4.x, XMLHttpRequest) object, a string describing the type of error that occurred and an optional exception object, if one occurred. Possible values for the second argument (besides null) are "timeout", "error", "abort", and "parsererror". When an HTTP error occurs, errorThrown receives the textual portion of the HTTP status, such as "Not Found" or "Internal Server Error." As of jQuery 1.5, the error setting can accept an array of functions. Each function will be called in turn. Note: This handler is not called for cross-domain script and cross-domain JSONP requests. This is an Ajax Event.
      */
@@ -83,47 +83,47 @@ interface JQueryAjaxSettings {
     /**
      * Whether to trigger global Ajax event handlers for this request. The default is true. Set to false to prevent the global handlers like ajaxStart or ajaxStop from being triggered. This can be used to control various Ajax Events.
      */
-        global?: boolean;
+    global?: boolean;
     /**
      * An object of additional header key/value pairs to send along with requests using the XMLHttpRequest transport. The header X-Requested-With: XMLHttpRequest is always added, but its default XMLHttpRequest value can be changed here. Values in the headers setting can also be overwritten from within the beforeSend function. (version added: 1.5)
      */
-        headers?: { [key: string]: any; };
+    headers?: { [key: string]: any; };
     /**
      * Allow the request to be successful only if the response has changed since the last request. This is done by checking the Last-Modified header. Default value is false, ignoring the header. In jQuery 1.4 this technique also checks the 'etag' specified by the server to catch unmodified data.
      */
-        ifModified?: boolean;
+    ifModified?: boolean;
     /**
      * Allow the current environment to be recognized as "local," (e.g. the filesystem), even if jQuery does not recognize it as such by default. The following protocols are currently recognized as local: file, *-extension, and widget. If the isLocal setting needs modification, it is recommended to do so once in the $.ajaxSetup() method. (version added: 1.5.1)
      */
-        isLocal?: boolean;
+    isLocal?: boolean;
     /**
      * Override the callback function name in a jsonp request. This value will be used instead of 'callback' in the 'callback=?' part of the query string in the url. So {jsonp:'onJSONPLoad'} would result in 'onJSONPLoad=?' passed to the server. As of jQuery 1.5, setting the jsonp option to false prevents jQuery from adding the "?callback" string to the URL or attempting to use "=?" for transformation. In this case, you should also explicitly set the jsonpCallback setting. For example, { jsonp: false, jsonpCallback: "callbackName" }
      */
-        jsonp?: string;
+    jsonp?: any;
     /**
      * Specify the callback function name for a JSONP request. This value will be used instead of the random name automatically generated by jQuery. It is preferable to let jQuery generate a unique name as it'll make it easier to manage the requests and provide callbacks and error handling. You may want to specify the callback when you want to enable better browser caching of GET requests. As of jQuery 1.5, you can also use a function for this setting, in which case the value of jsonpCallback is set to the return value of that function.
      */
-        jsonpCallback?: any;
+    jsonpCallback?: any;
     /**
      * A mime type to override the XHR mime type. (version added: 1.5.1)
      */
-        mimeType?: string;
+    mimeType?: string;
     /**
      * A password to be used with XMLHttpRequest in response to an HTTP access authentication request.
      */
-        password?: string;
+    password?: string;
     /**
      * By default, data passed in to the data option as an object (technically, anything other than a string) will be processed and transformed into a query string, fitting to the default content-type "application/x-www-form-urlencoded". If you want to send a DOMDocument, or other non-processed data, set this option to false.
      */
-        processData?: boolean;
+    processData?: boolean;
     /**
      * Only applies when the "script" transport is used (e.g., cross-domain requests with "jsonp" or "script" dataType and "GET" type). Sets the charset attribute on the script tag used in the request. Used when the character set on the local page is not the same as the one on the remote script.
      */
-        scriptCharset?: string;
+    scriptCharset?: string;
     /**
      * An object of numeric HTTP codes and functions to be called when the response has the corresponding code. f the request is successful, the status code functions take the same parameters as the success callback; if it results in an error (including 3xx redirect), they take the same parameters as the error callback. (version added: 1.5)
      */
-        statusCode?: { [key: string]: any; };
+    statusCode?: { [key: string]: any; };
     /**
      * A function to be called if the request succeeds. The function gets passed three arguments: The data returned from the server, formatted according to the dataType parameter; a string describing the status; and the jqXHR (in jQuery 1.4.x, XMLHttpRequest) object. As of jQuery 1.5, the success setting can accept an array of functions. Each function will be called in turn. This is an Ajax Event.
      */
@@ -131,31 +131,31 @@ interface JQueryAjaxSettings {
     /**
      * Set a timeout (in milliseconds) for the request. This will override any global timeout set with $.ajaxSetup(). The timeout period starts at the point the $.ajax call is made; if several other requests are in progress and the browser has no connections available, it is possible for a request to time out before it can be sent. In jQuery 1.4.x and below, the XMLHttpRequest object will be in an invalid state if the request times out; accessing any object members may throw an exception. In Firefox 3.0+ only, script and JSONP requests cannot be cancelled by a timeout; the script will run even if it arrives after the timeout period.
      */
-        timeout?: number;
+    timeout?: number;
     /**
      * Set this to true if you wish to use the traditional style of param serialization.
      */
-        traditional?: boolean;
+    traditional?: boolean;
     /**
      * The type of request to make ("POST" or "GET"), default is "GET". Note: Other HTTP request methods, such as PUT and DELETE, can also be used here, but they are not supported by all browsers.
      */
-        type?: string;
+    type?: string;
     /**
      * A string containing the URL to which the request is sent.
      */
-        url?: string;
+    url?: string;
     /**
      * A username to be used with XMLHttpRequest in response to an HTTP access authentication request.
      */
-        username?: string;
+    username?: string;
     /**
      * Callback for creating the XMLHttpRequest object. Defaults to the ActiveXObject when available (IE), the XMLHttpRequest otherwise. Override to provide your own implementation for XMLHttpRequest or enhancements to the factory.
      */
-        xhr?: any;
+    xhr?: any;
     /**
      * An object of fieldName-fieldValue pairs to set on the native XHR object. For example, you can use it to set withCredentials to true for cross-domain requests if needed. In jQuery 1.5, the withCredentials property was not propagated to the native XHR and thus CORS requests requiring it would ignore this flag. For this reason, we recommend using jQuery 1.5.1+ should you require the use of it. (version added: 1.5.1)
      */
-        xhrFields?: { [key: string]: any; };
+    xhrFields?: { [key: string]: any; };
 }
 
 /**
@@ -163,7 +163,7 @@ interface JQueryAjaxSettings {
  */
 interface JQueryXHR extends XMLHttpRequest, JQueryPromise<any> {
     /**
-     * The .overrideMimeType() method may be used in the beforeSend() callback function, for example, to modify the response content-type header. As of jQuery 1.5.1, the jqXHR object also contains the overrideMimeType() method (it was available in jQuery 1.4.x, as well, but was temporarily removed in jQuery 1.5).
+     * The .overrideMimeType() method may be used in the beforeSend() callback function, for example, to modify the response content-type header. As of jQuery 1.5.1, the jqXHR object also contains the overrideMimeType() method (it was available in jQuery 1.4.x, as well, but was temporarily removed in jQuery 1.5). 
      */
     overrideMimeType(mimeType: string): any;
     abort(statusText?: string): void;
@@ -175,13 +175,13 @@ interface JQueryXHR extends XMLHttpRequest, JQueryPromise<any> {
 interface JQueryCallback {
     /**
      * Add a callback or a collection of callbacks to a callback list.
-     *
+     * 
      * @param callbacks A function, or array of functions, that are to be added to the callback list.
      */
     add(callbacks: Function): JQueryCallback;
     /**
      * Add a callback or a collection of callbacks to a callback list.
-     *
+     * 
      * @param callbacks A function, or array of functions, that are to be added to the callback list.
      */
     add(callbacks: Function[]): JQueryCallback;
@@ -203,7 +203,7 @@ interface JQueryCallback {
 
     /**
      * Call all of the callbacks with the given arguments
-     *
+     * 
      * @param arguments The argument or list of arguments to pass back to the callback list.
      */
     fire(...arguments: any[]): JQueryCallback;
@@ -215,7 +215,7 @@ interface JQueryCallback {
 
     /**
      * Call all callbacks in a list with the given context and arguments.
-     *
+     * 
      * @param context A reference to the context in which the callbacks in the list should be fired.
      * @param arguments An argument, or array of arguments, to pass to the callbacks in the list.
      */
@@ -223,7 +223,7 @@ interface JQueryCallback {
 
     /**
      * Determine whether a supplied callback is in a list
-     *
+     * 
      * @param callback The callback to search for.
      */
     has(callback: Function): boolean;
@@ -240,21 +240,21 @@ interface JQueryCallback {
 
     /**
      * Remove a callback or a collection of callbacks from a callback list.
-     *
+     * 
      * @param callbacks A function, or array of functions, that are to be removed from the callback list.
      */
     remove(callbacks: Function): JQueryCallback;
     /**
      * Remove a callback or a collection of callbacks from a callback list.
-     *
+     * 
      * @param callbacks A function, or array of functions, that are to be removed from the callback list.
      */
     remove(callbacks: Function[]): JQueryCallback;
 }
 
 /*
- Allows jQuery Promises to interop with non-jQuery promises
- */
+    Allows jQuery Promises to interop with non-jQuery promises
+*/
 interface JQueryGenericPromise<T> {
     then<U>(onFulfill: (value: T) => U, onReject?: (reason: any) => U): JQueryGenericPromise<U>;
     then<U>(onFulfill: (value: T) => JQueryGenericPromise<U>, onReject?: (reason: any) => U): JQueryGenericPromise<U>;
@@ -263,8 +263,8 @@ interface JQueryGenericPromise<T> {
 }
 
 /*
- Interface for the JQuery promise, part of callbacks
- */
+    Interface for the JQuery promise, part of callbacks
+*/
 interface JQueryPromise<T> {
     // Generic versions of callbacks
     always(...alwaysCallbacks: T[]): JQueryPromise<T>;
@@ -285,7 +285,6 @@ interface JQueryPromise<T> {
     then<U>(onFulfill: (value: T) => JQueryGenericPromise<U>, onReject?: (...reasons: any[]) => U, onProgress?: (...progression: any[]) => any): JQueryPromise<U>;
     then<U>(onFulfill: (value: T) => U, onReject?: (...reasons: any[]) => JQueryGenericPromise<U>, onProgress?: (...progression: any[]) => any): JQueryPromise<U>;
     then<U>(onFulfill: (value: T) => JQueryGenericPromise<U>, onReject?: (...reasons: any[]) => JQueryGenericPromise<U>, onProgress?: (...progression: any[]) => any): JQueryPromise<U>;
-    then<U>(onFulfill: (value: T) => JQueryGenericPromise<U>, onReject?: (...reasons: any[]) => JQueryGenericPromise<U>, onProgress?: (...progression: any[]) => any): JQueryPromise<U>;
 
     // Because JQuery Promises Suck
     then<U>(onFulfill: (...values: any[]) => U, onReject?: (...reasons: any[]) => U, onProgress?: (...progression: any[]) => any): JQueryPromise<U>;
@@ -295,8 +294,8 @@ interface JQueryPromise<T> {
 }
 
 /*
- Interface for the JQuery deferred, part of callbacks
- */
+    Interface for the JQuery deferred, part of callbacks
+*/
 interface JQueryDeferred<T> extends JQueryPromise<T> {
     // Generic versions of callbacks
     always(...alwaysCallbacks: T[]): JQueryDeferred<T>;
@@ -324,8 +323,8 @@ interface JQueryDeferred<T> extends JQueryPromise<T> {
 }
 
 /*
- Interface of the JQuery extension of the W3C event object
- */
+    Interface of the JQuery extension of the W3C event object
+*/
 
 interface BaseJQueryEventObject extends Event {
     data: any;
@@ -379,8 +378,8 @@ interface JQueryEventObject extends BaseJQueryEventObject, JQueryInputEventObjec
 }
 
 /*
- Collection of properties of the current browser
- */
+    Collection of properties of the current browser
+*/
 
 interface JQuerySupport {
     ajax?: boolean;
@@ -407,14 +406,14 @@ interface JQuerySupport {
 interface JQueryParam {
     /**
      * Create a serialized representation of an array or object, suitable for use in a URL query string or Ajax request.
-     *
+     * 
      * @param obj An array or object to serialize.
      */
     (obj: any): string;
 
     /**
      * Create a serialized representation of an array or object, suitable for use in a URL query string or Ajax request.
-     *
+     * 
      * @param obj An array or object to serialize.
      * @param traditional A Boolean indicating whether to perform a traditional "shallow" serialization.
      */
@@ -440,51 +439,51 @@ interface JQueryCoordinates {
     top: number;
 }
 
-interface JQueryAnimationOptions {
+interface JQueryAnimationOptions { 
     /**
      * A string or number determining how long the animation will run.
      */
-        duration?: any;
+    duration?: any; 
     /**
      * A string indicating which easing function to use for the transition.
      */
-        easing?: string;
+    easing?: string; 
     /**
      * A function to call once the animation is complete.
      */
-        complete?: Function;
+    complete?: Function; 
     /**
      * A function to be called for each animated property of each animated element. This function provides an opportunity to modify the Tween object to change the value of the property before it is set.
      */
-        step?: (now: number, tween: any) => any;
+    step?: (now: number, tween: any) => any; 
     /**
      * A function to be called after each step of the animation, only once per animated element regardless of the number of animated properties. (version added: 1.8)
      */
-        progress?: (animation: JQueryPromise<any>, progress: number, remainingMs: number) => any;
+    progress?: (animation: JQueryPromise<any>, progress: number, remainingMs: number) => any; 
     /**
      * A function to call when the animation begins. (version added: 1.8)
      */
-        start?: (animation: JQueryPromise<any>) => any;
+    start?: (animation: JQueryPromise<any>) => any; 
     /**
      * A function to be called when the animation completes (its Promise object is resolved). (version added: 1.8)
      */
-        done?: (animation: JQueryPromise<any>, jumpedToEnd: boolean) => any;
+    done?: (animation: JQueryPromise<any>, jumpedToEnd: boolean) => any; 
     /**
      * A function to be called when the animation fails to complete (its Promise object is rejected). (version added: 1.8)
      */
-        fail?: (animation: JQueryPromise<any>, jumpedToEnd: boolean) => any;
+    fail?: (animation: JQueryPromise<any>, jumpedToEnd: boolean) => any; 
     /**
      * A function to be called when the animation completes or stops without completing (its Promise object is either resolved or rejected). (version added: 1.8)
      */
-        always?: (animation: JQueryPromise<any>, jumpedToEnd: boolean) => any;
+    always?: (animation: JQueryPromise<any>, jumpedToEnd: boolean) => any; 
     /**
      * A Boolean indicating whether to place the animation in the effects queue. If false, the animation will begin immediately. As of jQuery 1.7, the queue option can also accept a string, in which case the animation is added to the queue represented by that string. When a custom queue name is used the animation does not automatically start; you must call .dequeue("queuename") to start it.
      */
-        queue?: any;
+    queue?: any; 
     /**
      * A map of one or more of the CSS properties defined by the properties argument and their corresponding easing functions. (version added: 1.4)
      */
-        specialEasing?: Object;
+    specialEasing?: Object;
 }
 
 /**
@@ -530,11 +529,11 @@ interface JQueryStatic {
 
     ajaxSettings: JQueryAjaxSettings;
 
-    /**
-     * Set default values for future Ajax requests. Its use is not recommended.
-     *
-     * @param options A set of key/value pairs that configure the default Ajax request. All options are optional.
-     */
+     /**
+      * Set default values for future Ajax requests. Its use is not recommended.
+      *
+      * @param options A set of key/value pairs that configure the default Ajax request. All options are optional.
+      */
     ajaxSetup(options: JQueryAjaxSettings): void;
 
     /**
@@ -597,7 +596,7 @@ interface JQueryStatic {
     /**
      * Create a serialized representation of an array or object, suitable for use in a URL query string or Ajax request.
      */
-        param: JQueryParam;
+    param: JQueryParam;
 
     /**
      * Load data from the server using a HTTP POST request.
@@ -734,7 +733,7 @@ interface JQueryStatic {
     /**
      * Hook directly into jQuery to override how particular CSS properties are retrieved or set, normalize CSS property naming, or create custom properties.
      */
-        cssHooks: { [key: string]: any; };
+    cssHooks: { [key: string]: any; };
     cssNumber: any;
 
     /**
@@ -816,18 +815,18 @@ interface JQueryStatic {
     /**
      * Effects
      */
-        fx: {
+    fx: {
         tick: () => void;
         /**
          * The rate (in milliseconds) at which animations fire.
          */
-            interval: number;
+        interval: number;
         stop: () => void;
         speeds: { slow: number; fast: number; };
         /**
          * Globally disable all animations.
          */
-            off: boolean;
+        off: boolean;
         step: any;
     };
 
@@ -867,7 +866,7 @@ interface JQueryStatic {
 
     /**
      * Check to see if a DOM element is a descendant of another DOM element.
-     *
+     * 
      * @param container The DOM element that may contain the other element.
      * @param contained The DOM element that may be contained by (a descendant of) the other element.
      */
@@ -875,7 +874,7 @@ interface JQueryStatic {
 
     /**
      * A generic iterator function, which can be used to seamlessly iterate over both objects and arrays. Arrays and array-like objects with a length property (such as a function's arguments object) are iterated by numeric index, from 0 to length-1. Other objects are iterated via their named properties.
-     *
+     * 
      * @param collection The object or array to iterate over.
      * @param callback The function that will be executed on every object.
      */
@@ -886,7 +885,7 @@ interface JQueryStatic {
 
     /**
      * A generic iterator function, which can be used to seamlessly iterate over both objects and arrays. Arrays and array-like objects with a length property (such as a function's arguments object) are iterated by numeric index, from 0 to length-1. Other objects are iterated via their named properties.
-     *
+     * 
      * @param collection The object or array to iterate over.
      * @param callback The function that will be executed on every object.
      */
@@ -895,36 +894,138 @@ interface JQueryStatic {
         callback: (indexInArray: any, valueOfElement: any) => any
         ): any;
 
-    extend(target: any, ...objs: any[]): any;
-    extend(deep: boolean, target: any, ...objs: any[]): any;
+    /**
+     * Merge the contents of two or more objects together into the first object.
+     *
+     * @param target An object that will receive the new properties if additional objects are passed in or that will extend the jQuery namespace if it is the sole argument.
+     * @param object1 An object containing additional properties to merge in.
+     * @param objectN Additional objects containing properties to merge in.
+     */
+    extend(target: any, object1?: any, ...objectN: any[]): any;
+    /**
+     * Merge the contents of two or more objects together into the first object.
+     *
+     * @param deep If true, the merge becomes recursive (aka. deep copy).
+     * @param target The object to extend. It will receive the new properties.
+     * @param object1 An object containing additional properties to merge in.
+     * @param objectN Additional objects containing properties to merge in.
+     */
+    extend(deep: boolean, target: any, object1?: any, ...objectN: any[]): any;
 
+    /**
+     * Execute some JavaScript code globally.
+     *
+     * @param code The JavaScript code to execute.
+     */
     globalEval(code: string): any;
 
+    /**
+     * Finds the elements of an array which satisfy a filter function. The original array is not affected.
+     *
+     * @param array The array to search through.
+     * @param func The function to process each item against. The first argument to the function is the item, and the second argument is the index. The function should return a Boolean value.  this will be the global window object.
+     * @param invert If "invert" is false, or not provided, then the function returns an array consisting of all elements for which "callback" returns true. If "invert" is true, then the function returns an array consisting of all elements for which "callback" returns false.
+     */
     grep<T>(array: T[], func: (elementOfArray: T, indexInArray: number) => boolean, invert?: boolean): T[];
 
+    /**
+     * Search for a specified value within an array and return its index (or -1 if not found).
+     *
+     * @param value The value to search for.
+     * @param array An array through which to search.
+     * @param fromIndex he index of the array at which to begin the search. The default is 0, which will search the whole array.
+     */
     inArray<T>(value: T, array: T[], fromIndex?: number): number;
 
+    /**
+     * Determine whether the argument is an array.
+     *
+     * @param obj Object to test whether or not it is an array.
+     */
     isArray(obj: any): boolean;
+    /**
+     * Check to see if an object is empty (contains no enumerable properties).
+     *
+     * @param obj The object that will be checked to see if it's empty.
+     */
     isEmptyObject(obj: any): boolean;
+    /**
+     * Determine if the argument passed is a Javascript function object.
+     *
+     * @param obj Object to test whether or not it is a function.
+     */
     isFunction(obj: any): boolean;
+    /**
+     * Determines whether its argument is a number.
+     *
+     * @param obj The value to be tested.
+     */
     isNumeric(value: any): boolean;
+    /**
+     * Check to see if an object is a plain object (created using "{}" or "new Object").
+     *
+     * @param obj The object that will be checked to see if it's a plain object.
+     */
     isPlainObject(obj: any): boolean;
+    /**
+     * Determine whether the argument is a window.
+     *
+     * @param obj Object to test whether or not it is a window.
+     */
     isWindow(obj: any): boolean;
+    /**
+     * Check to see if a DOM node is within an XML document (or is an XML document).
+     *
+     * @param node he DOM node that will be checked to see if it's in an XML document.
+     */
     isXMLDoc(node: Node): boolean;
 
+    /**
+     * Convert an array-like object into a true JavaScript array.
+     * 
+     * @param obj Any object to turn into a native Array.
+     */
     makeArray(obj: any): any[];
 
+    /**
+     * Translate all items in an array or object to new array of items.
+     * 
+     * @param array The Array to translate.
+     * @param callback The function to process each item against. The first argument to the function is the array item, the second argument is the index in array The function can return any value. Within the function, this refers to the global (window) object.
+     */
     map<T, U>(array: T[], callback: (elementOfArray: T, indexInArray: number) => U): U[];
-    map(array: any, callback: (elementOfArray: any, indexInArray: any) => any): any;
+    /**
+     * Translate all items in an array or object to new array of items.
+     * 
+     * @param arrayOrObject The Array or Object to translate.
+     * @param callback The function to process each item against. The first argument to the function is the value; the second argument is the index or key of the array or object property. The function can return any value to add to the array. A returned array will be flattened into the resulting array. Within the function, this refers to the global (window) object.
+     */
+    map(arrayOrObject: any, callback: (value: any, indexOrKey: any) => any): any;
 
+    /**
+     * Merge the contents of two arrays together into the first array.
+     * 
+     * @param first The first array to merge, the elements of second added.
+     * @param second The second array to merge into the first, unaltered.
+     */
     merge<T>(first: T[], second: T[]): T[];
-    merge<T,U>(first: T[], second: U[]): any[];
 
+    /**
+     * An empty function.
+     */
     noop(): any;
 
+    /**
+     * Return a number representing the current time.
+     */
     now(): number;
 
-    parseJSON(json: string): any;
+    /**
+     * Takes a well-formed JSON string and returns the resulting JavaScript object.
+     * 
+     * @param json The JSON string to parse.
+     */
+    parseJSON(json: string): Object;
 
     /**
      * Parses a string into an XML document.
@@ -933,13 +1034,26 @@ interface JQueryStatic {
      */
     parseXML(data: string): XMLDocument;
 
-    queue(element: Element, queueName: string, newQueue: any[]): JQuery;
-
+    /**
+     * Remove the whitespace from the beginning and end of a string.
+     * 
+     * @param str Remove the whitespace from the beginning and end of a string.
+     */
     trim(str: string): string;
 
+    /**
+     * Determine the internal JavaScript [[Class]] of an object.
+     * 
+     * @param obj Object to get the internal JavaScript [[Class]] of.
+     */
     type(obj: any): string;
 
-    unique(arr: any[]): any[];
+    /**
+     * Sorts an array of DOM elements, in place, with the duplicates removed. Note that this only works on arrays of DOM elements, not strings or numbers.
+     * 
+     * @param array The Array of DOM elements.
+     */
+    unique(array: Element[]): Element[];
 
     /**
      * Parses a string into an array of DOM nodes.
@@ -949,10 +1063,6 @@ interface JQueryStatic {
      * @param keepScripts A Boolean indicating whether to include scripts passed in the HTML string
      */
     parseHTML(data: string, context?: HTMLElement, keepScripts?: boolean): any[];
-
-    Animation(elem: any, properties: any, options: any): any;
-
-    easing: JQueryEasing;
 }
 
 /**
@@ -1045,14 +1155,14 @@ interface JQuery {
      *
      * @param attributeName The name of the attribute to get.
      */
-    attr(attributeName: any): string;
+    attr(attributeName: string): string;
     /**
      * Set one or more attributes for the set of matched elements.
      *
      * @param attributeName The name of the attribute to set.
      * @param value A value to set for the attribute.
      */
-    attr(attributeName: any, value: any): JQuery;
+    attr(attributeName: string, value: string): JQuery;
     /**
      * Set one or more attributes for the set of matched elements.
      *
@@ -1073,7 +1183,7 @@ interface JQuery {
      * @param attributes An object of attribute-value pairs to set.
      */
     attr(attributes: Object): JQuery;
-
+    
     /**
      * Determine whether any of the matched elements are assigned the given class.
      *
@@ -1201,7 +1311,7 @@ interface JQuery {
      *
      * @param value A string of text or an array of strings corresponding to the value of each matched element to set as selected/checked.
      */
-    val(value: any): JQuery;
+    val(value: string): JQuery;
     /**
      * Set the value of each element in the set of matched elements.
      *
@@ -2280,9 +2390,7 @@ interface JQuery {
      * @param handler A function to execute when the event is triggered. The value false is also allowed as a shorthand for a function that simply does return false. Rest parameter args is for optional parameters passed to jQuery.trigger(). Note that the actual parameters on the event handler function must be marked as optional (? syntax).
      */
     on(events: string, handler: (eventObject: JQueryEventObject, ...args: any[]) => any): JQuery;
-    on(events: string, handler: (eventObject: JQueryEventObject, arg: any) => any): JQuery;
-    on(events: string, reference: any, data: (eventObject: JQueryEventObject, arg: any) => any): JQuery;
-
+    on(events: string, handler: (eventObject: JQueryEventObject, data: any) => any): JQuery;
     /**
      * Attach an event handler function for one or more events to the selected elements.
      *
@@ -2475,8 +2583,6 @@ interface JQuery {
 
     detach(selector?: any): JQuery;
 
-    dotdotdot(data: any);
-
     empty(): JQuery;
 
     insertAfter(target: any): JQuery;
@@ -2511,7 +2617,7 @@ interface JQuery {
 
     /**
      * Iterate over a jQuery object, executing a function for each matched element.
-     *
+     * 
      * @param func A function to execute for each matched element.
      */
     each(func: (index: number, elem: Element) => any): JQuery;
@@ -2562,11 +2668,6 @@ interface JQuery {
     has(selector: string): JQuery;
     has(contained: Element): JQuery;
 
-    hideError();
-
-    invisible();
-    invisible(invisible: boolean);
-
     is(selector: string): boolean;
     is(func: (index: any) => any): boolean;
     is(element: any): boolean;
@@ -2607,22 +2708,25 @@ interface JQuery {
     prevUntil(element?: Element, filter?: string): JQuery;
     prevUntil(obj?: JQuery, filter?: string): JQuery;
 
-    showError(message: string);
-
     siblings(selector?: string): JQuery;
 
     slice(start: number, end?: number): JQuery;
-
-    visible();
 
     // Utilities
 
     queue(queueName?: string): any[];
     queue(queueName: string, newQueueOrCallback: any): JQuery;
     queue(newQueueOrCallback: any): JQuery;
+
+    // 2014-02-10 JayBeavers: ChronoZoom Extensions to JQuery, added into the ts definitions file
+    dotdotdot(data: any): JQuery;
+    showError(message: string): JQuery;
+    hideError(): JQuery;
+    visible(noTransition?: boolean): JQuery;
+    invisible(noTransition?: boolean): JQuery;
 }
 declare module "jquery" {
-export = $;
+    export = $;
 }
 declare var jQuery: JQueryStatic;
 declare var $: JQueryStatic;

--- a/Source/Chronozoom.UI/scripts/typings/jqueryui/jqueryui.d.ts
+++ b/Source/Chronozoom.UI/scripts/typings/jqueryui/jqueryui.d.ts
@@ -73,7 +73,7 @@ declare module JQueryUI {
     }
 
     interface Autocomplete extends Widget, AutocompleteOptions, AutocompleteEvents {
-        escapeRegex: (string) => string;
+        escapeRegex: (value: string) => string;
     }
 
 
@@ -154,10 +154,10 @@ declare module JQueryUI {
 
     interface Datepicker extends Widget, DatepickerOptions {
         regional: { [languageCod3: string]: any; };
-        setDefaults(defaults: DatepickerOptions);
+        setDefaults(defaults: DatepickerOptions): void;
         formatDate(format: string, date: Date, settings?: DatepickerFormatDateOptions): string;
         parseDate(format: string, date: string, settings?: DatepickerFormatDateOptions): Date;
-        iso8601Week(date: Date): void;
+        iso8601Week(date: Date): number;
         noWeekends(): void;
     }
 
@@ -185,6 +185,8 @@ declare module JQueryUI {
         title?: string;
         width?: any; // number or string
         zIndex?: number;
+
+        close?: DialogEvent;
     }
 
     interface DialogUIParams {
@@ -463,8 +465,8 @@ declare module JQueryUI {
     interface SortableOptions {
         appendTo?: any; // jQuery, Element, Selector or string
         axis?: string;
-        cancel?: string;
-        connectWith?: string;
+        cancel?: any; // Selector
+        connectWith?: any; // Selector
         containment?: any; // Element, Selector or string
         cursor?: string;
         cursorAt?: any;
@@ -561,9 +563,15 @@ declare module JQueryUI {
         heightStyle?: string;
         hide?: any; // boolean, number, string or object
         show?: any; // boolean, number, string or object
+
+        activate?: TabsEvent;
     }
 
     interface TabsUIParams {
+        newTab: JQuery;
+        oldTab: JQuery;
+        newPanel: JQuery;
+        oldPanel: JQuery;
     }
 
     interface TabsEvent {
@@ -781,59 +789,58 @@ declare module JQueryUI {
 interface JQuery {
 
     accordion(): JQuery;
-    accordion(methodName: string): JQuery;
     accordion(methodName: 'destroy'): void;
     accordion(methodName: 'disable'): void;
     accordion(methodName: 'enable'): void;
     accordion(methodName: 'refresh'): void;
     accordion(methodName: 'widget'): JQuery;
+    accordion(methodName: string): JQuery;
     accordion(options: JQueryUI.AccordionOptions): JQuery;
     accordion(optionLiteral: string, optionName: string): any;
     accordion(optionLiteral: string, options: JQueryUI.AccordionOptions): any;
     accordion(optionLiteral: string, optionName: string, optionValue: any): JQuery;
 
     autocomplete(): JQuery;
-    autocomplete(methodName: string): JQuery;
     autocomplete(methodName: 'close'): void;
     autocomplete(methodName: 'destroy'): void;
     autocomplete(methodName: 'disable'): void;
     autocomplete(methodName: 'enable'): void;
     autocomplete(methodName: 'search', value?: string): void;
     autocomplete(methodName: 'widget'): JQuery;
+    autocomplete(methodName: string): JQuery;
     autocomplete(options: JQueryUI.AutocompleteOptions): JQuery;
     autocomplete(optionLiteral: string, optionName: string): any;
     autocomplete(optionLiteral: string, options: JQueryUI.AutocompleteOptions): any;
     autocomplete(optionLiteral: string, optionName: string, optionValue: any): JQuery;
 
     button(): JQuery;
-    button(methodName: string): JQuery;
     button(methodName: 'destroy'): void;
     button(methodName: 'disable'): void;
     button(methodName: 'enable'): void;
     button(methodName: 'refresh'): void;
     button(methodName: 'widget'): JQuery;
+    button(methodName: string): JQuery;
     button(options: JQueryUI.ButtonOptions): JQuery;
     button(optionLiteral: string, optionName: string): any;
     button(optionLiteral: string, options: JQueryUI.ButtonOptions): any;
     button(optionLiteral: string, optionName: string, optionValue: any): JQuery;
 
     buttonset(): JQuery;
-    buttonset(methodName: string): JQuery;
     buttonset(methodName: 'destroy'): void;
     buttonset(methodName: 'disable'): void;
     buttonset(methodName: 'enable'): void;
     buttonset(methodName: 'refresh'): void;
     buttonset(methodName: 'widget'): JQuery;
+    buttonset(methodName: string): JQuery;
     buttonset(options: JQueryUI.ButtonOptions): JQuery;
     buttonset(optionLiteral: string, optionName: string): any;
     buttonset(optionLiteral: string, options: JQueryUI.ButtonOptions): any;
     buttonset(optionLiteral: string, optionName: string, optionValue: any): JQuery;
 
     datepicker(): JQuery;
-    datepicker(methodName: string): JQuery;
     datepicker(methodName: 'destroy'): void;
-    datepicker(methodName: 'dialog', date?: Date, onSelect?: () => void, pos?: any): void;
-    datepicker(methodName: 'dialog', date?: string, onSelect?: () => void, pos?: any): void;
+    datepicker(methodName: 'dialog', date?: Date, onSelect?: () => void , pos?: any): void;
+    datepicker(methodName: 'dialog', date?: string, onSelect?: () => void , pos?: any): void;
     datepicker(methodName: 'getDate'): Date;
     datepicker(methodName: 'hide'): void;
     datepicker(methodName: 'isDisabled'): boolean;
@@ -842,48 +849,48 @@ interface JQuery {
     datepicker(methodName: 'setDate', date: string): void;
     datepicker(methodName: 'show'): void;
     datepicker(methodName: 'widget'): JQuery;
+    datepicker(methodName: string): JQuery;
     datepicker(options: JQueryUI.DatepickerOptions): JQuery;
     datepicker(optionLiteral: string, optionName: string): any;
     datepicker(optionLiteral: string, options: JQueryUI.DatepickerOptions): any;
     datepicker(optionLiteral: string, optionName: string, optionValue: any): JQuery;
 
     dialog(): JQuery;
-    dialog(methodName: string): JQuery;
-    dialog(methodName: 'close'): void;
-    dialog(methodName: 'destroy'): void;
+    dialog(methodName: 'close'): JQuery;
+    dialog(methodName: 'destroy'): JQuery;
     dialog(methodName: 'isOpen'): boolean;
-    dialog(methodName: 'moveToTop'): void;
-    dialog(methodName: 'open'): void;
+    dialog(methodName: 'moveToTop'): JQuery;
+    dialog(methodName: 'open'): JQuery;
     dialog(methodName: 'widget'): JQuery;
+    dialog(methodName: string): JQuery;
     dialog(options: JQueryUI.DialogOptions): JQuery;
     dialog(optionLiteral: string, optionName: string): any;
     dialog(optionLiteral: string, options: JQueryUI.DialogOptions): any;
     dialog(optionLiteral: string, optionName: string, optionValue: any): JQuery;
 
     draggable(): JQuery;
-    draggable(methodName: string): JQuery;
     draggable(methodName: 'destroy'): void;
     draggable(methodName: 'disable'): void;
     draggable(methodName: 'enable'): void;
     draggable(methodName: 'widget'): JQuery;
+    draggable(methodName: string): JQuery;
     draggable(options: JQueryUI.DraggableOptions): JQuery;
     draggable(optionLiteral: string, optionName: string): any;
     draggable(optionLiteral: string, options: JQueryUI.DraggableOptions): any;
     draggable(optionLiteral: string, optionName: string, optionValue: any): JQuery;
 
     droppable(): JQuery;
-    droppable(methodName: string): JQuery;
     droppable(methodName: 'destroy'): void;
     droppable(methodName: 'disable'): void;
     droppable(methodName: 'enable'): void;
     droppable(methodName: 'widget'): JQuery;
+    droppable(methodName: string): JQuery;
     droppable(options: JQueryUI.DroppableOptions): JQuery;
     droppable(optionLiteral: string, optionName: string): any;
     droppable(optionLiteral: string, options: JQueryUI.DraggableOptions): any;
     droppable(optionLiteral: string, optionName: string, optionValue: any): JQuery;
 
     menu(): JQuery;
-    menu(methodName: string): JQuery;
     menu(methodName: 'blur'): void;
     menu(methodName: 'collapse', event?: JQueryEventObject): void;
     menu(methodName: 'collapseAll', event?: JQueryEventObject, all?: boolean): void;
@@ -901,13 +908,13 @@ interface JQuery {
     menu(methodName: 'refresh'): void;
     menu(methodName: 'select', event?: JQueryEventObject): void;
     menu(methodName: 'widget'): JQuery;
+    menu(methodName: string): JQuery;
     menu(options: JQueryUI.MenuOptions): JQuery;
     menu(optionLiteral: string, optionName: string): any;
     menu(optionLiteral: string, options: JQueryUI.MenuOptions): any;
     menu(optionLiteral: string, optionName: string, optionValue: any): JQuery;
 
     progressbar(): JQuery;
-    progressbar(methodName: string): JQuery;
     progressbar(methodName: 'destroy'): void;
     progressbar(methodName: 'disable'): void;
     progressbar(methodName: 'enable'): void;
@@ -916,35 +923,35 @@ interface JQuery {
     progressbar(methodName: 'value', value: number): void;
     progressbar(methodName: 'value', value: boolean): void;
     progressbar(methodName: 'widget'): JQuery;
+    progressbar(methodName: string): JQuery;
     progressbar(options: JQueryUI.ProgressbarOptions): JQuery;
     progressbar(optionLiteral: string, optionName: string): any;
     progressbar(optionLiteral: string, options: JQueryUI.ProgressbarOptions): any;
     progressbar(optionLiteral: string, optionName: string, optionValue: any): JQuery;
 
     resizable(): JQuery;
-    resizable(methodName: string): JQuery;
     resizable(methodName: 'destroy'): void;
     resizable(methodName: 'disable'): void;
     resizable(methodName: 'enable'): void;
     resizable(methodName: 'widget'): JQuery;
+    resizable(methodName: string): JQuery;
     resizable(options: JQueryUI.ResizableOptions): JQuery;
     resizable(optionLiteral: string, optionName: string): any;
     resizable(optionLiteral: string, options: JQueryUI.ResizableOptions): any;
     resizable(optionLiteral: string, optionName: string, optionValue: any): JQuery;
 
     selectable(): JQuery;
-    selectable(methodName: string): JQuery;
     selectable(methodName: 'destroy'): void;
     selectable(methodName: 'disable'): void;
     selectable(methodName: 'enable'): void;
     selectable(methodName: 'widget'): JQuery;
+    selectable(methodName: string): JQuery;
     selectable(options: JQueryUI.SelectableOptions): JQuery;
     selectable(optionLiteral: string, optionName: string): any;
     selectable(optionLiteral: string, options: JQueryUI.SelectableOptions): any;
     selectable(optionLiteral: string, optionName: string, optionValue: any): JQuery;
 
     slider(): JQuery;
-    slider(methodName: string): JQuery;
     slider(methodName: 'destroy'): void;
     slider(methodName: 'disable'): void;
     slider(methodName: 'enable'): void;
@@ -958,24 +965,24 @@ interface JQuery {
     slider(methodName: string, values: Array<number>): void;
     slider(methodName: 'values', values: Array<number>): void;
     slider(methodName: 'widget'): JQuery;
+    slider(methodName: string): JQuery;
     slider(options: JQueryUI.SliderOptions): JQuery;
     slider(optionLiteral: string, optionName: string): any;
     slider(optionLiteral: string, options: JQueryUI.SliderOptions): any;
     slider(optionLiteral: string, optionName: string, optionValue: any): JQuery;
 
     sortable(): JQuery;
-    sortable(methodName: string): JQuery;
     sortable(methodName: 'destroy'): void;
     sortable(methodName: 'disable'): void;
     sortable(methodName: 'enable'): void;
     sortable(methodName: 'widget'): JQuery;
+    sortable(methodName: string): JQuery;
     sortable(options: JQueryUI.SortableOptions): JQuery;
     sortable(optionLiteral: string, optionName: string): any;
     sortable(optionLiteral: string, options: JQueryUI.SortableOptions): any;
     sortable(optionLiteral: string, optionName: string, optionValue: any): JQuery;
 
     spinner(): JQuery;
-    spinner(methodName: string): JQuery;
     spinner(methodName: 'destroy'): void;
     spinner(methodName: 'disable'): void;
     spinner(methodName: 'enable'): void;
@@ -986,32 +993,33 @@ interface JQuery {
     spinner(methodName: 'value'): number;
     spinner(methodName: 'value', value: number): void;
     spinner(methodName: 'widget'): JQuery;
+    spinner(methodName: string): JQuery;
     spinner(options: JQueryUI.SpinnerOptions): JQuery;
     spinner(optionLiteral: string, optionName: string): any;
     spinner(optionLiteral: string, options: JQueryUI.SpinnerOptions): any;
     spinner(optionLiteral: string, optionName: string, optionValue: any): JQuery;
 
     tabs(): JQuery;
-    tabs(methodName: string): JQuery;
     tabs(methodName: 'destroy'): void;
     tabs(methodName: 'disable'): void;
     tabs(methodName: 'enable'): void;
     tabs(methodName: 'load', index: number): void;
     tabs(methodName: 'refresh'): void;
     tabs(methodName: 'widget'): JQuery;
+    tabs(methodName: string): JQuery;
     tabs(options: JQueryUI.TabsOptions): JQuery;
     tabs(optionLiteral: string, optionName: string): any;
     tabs(optionLiteral: string, options: JQueryUI.TabsOptions): any;
     tabs(optionLiteral: string, optionName: string, optionValue: any): JQuery;
 
     tooltip(): JQuery;
-    tooltip(methodName: string): JQuery;
     tooltip(methodName: 'destroy'): void;
     tooltip(methodName: 'disable'): void;
     tooltip(methodName: 'enable'): void;
     tooltip(methodName: 'open'): void;
     tooltip(methodName: 'close'): void;
     tooltip(methodName: 'widget'): JQuery;
+    tooltip(methodName: string): JQuery;
     tooltip(options: JQueryUI.TooltipOptions): JQuery;
     tooltip(optionLiteral: string, optionName: string): any;
     tooltip(optionLiteral: string, options: JQueryUI.TooltipOptions): any;

--- a/Source/Chronozoom.UI/scripts/typings/rx.js/rx.js.d.ts
+++ b/Source/Chronozoom.UI/scripts/typings/rx.js/rx.js.d.ts
@@ -1,453 +1,356 @@
-﻿// Type definitions for RxJS
+// Type definitions for RxJS
 // Project: http://rx.codeplex.com/
 // Definitions by: gsino <http://www.codeplex.com/site/users/view/gsino>
+// Definitions by: Igor Oleinikov <https://github.com/Igorbek>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
-
 declare module Rx {
-    export module Internals {
-        function inherits(child: Function, parent: Function): Function;
-        function addProperties(obj: Object, ...sourcces: Object[]): void;
-        function addRef(xs: IObservable, r: { getDisposable(): _IDisposable; }): IObservable;
+	export module Internals {
+		function isEqual(left: any, right: any): boolean;
+		function inherits(child: Function, parent: Function): Function;
+		function addProperties(obj: Object, ...sourcces: Object[]): void;
+		function addRef<T>(xs: Observable<T>, r: { getDisposable(): IDisposable; }): Observable<T>;
+
+		// Priority Queue for Scheduling
+		export class PriorityQueue<TTime> {
+			constructor(capacity: number);
+
+			length: number;
+
+			isHigherPriority(left: number, right: number): boolean;
+			percolate(index: number): void;
+			heapify(index: number): void;
+			peek(): ScheduledItem<TTime>;
+			removeAt(index: number): void;
+			dequeue(): ScheduledItem<TTime>;
+			enqueue(item: ScheduledItem<TTime>): void;
+			remove(item: ScheduledItem<TTime>): boolean;
+
+			static count: number;
+		}
+
+		export class ScheduledItem<TTime> {
+			constructor(scheduler: IScheduler, state: any, action: (scheduler: IScheduler, state: any) => IDisposable, dueTime: TTime, comparer?: (x: TTime, y: TTime) => number);
+
+			scheduler: IScheduler;
+			state: TTime;
+			action: (scheduler: IScheduler, state: any) => IDisposable;
+			dueTime: TTime;
+			comparer: (x: TTime, y: TTime) => number;
+			disposable: SingleAssignmentDisposable;
+
+			invoke(): void;
+			compareTo(other: ScheduledItem<TTime>): number;
+			isCancelled(): boolean;
+			invokeCore(): IDisposable;
+		}
+	}
+
+	export interface IDisposable {
+		dispose(): void;
+	}
+
+	export class CompositeDisposable implements IDisposable {
+		constructor (...disposables: IDisposable[]);
+		constructor (disposables: IDisposable[]);
+
+		isDisposed: boolean;
+		length: number;
+
+		dispose(): void;
+		add(item: IDisposable): void;
+		remove(item: IDisposable): boolean;
+		clear(): void;
+		contains(item: IDisposable): boolean;
+		toArray(): IDisposable[];
+	}
+
+	export class Disposable implements IDisposable {
+		constructor(action: () => void);
+
+		static create(action: () => void): IDisposable;
+		static empty: IDisposable;
+
+		dispose(): void;
+	}
+
+	// Single assignment
+	export class SingleAssignmentDisposable implements IDisposable {
+		constructor();
+
+		isDisposed: boolean;
+		current: IDisposable;
+
+		dispose(): void ;
+		getDisposable(): IDisposable;
+		setDisposable(value: IDisposable): void ;
+	}
+
+	// Multiple assignment disposable
+	export class SerialDisposable implements IDisposable {
+		constructor();
+
+		isDisposed: boolean;
+
+		dispose(): void;
+		getDisposable(): IDisposable;
+		setDisposable(value: IDisposable): void;
+	}
+
+	export class RefCountDisposable implements IDisposable {
+		constructor(disposable: IDisposable);
+
+		dispose(): void;
+
+		isDisposed: boolean;
+		getDisposable(): IDisposable;
+	}
+
+	export interface IScheduler {
+		now(): number;
+		catch(handler: (exception: any) => boolean): IScheduler;
+		catchException(handler: (exception: any) => boolean): IScheduler;
+
+		schedule(action: () => void): IDisposable;
+		scheduleWithState<TState>(state: TState, action: (scheduler: IScheduler, state: TState) => IDisposable): IDisposable;
+		scheduleWithAbsolute(dueTime: number, action: () => void): IDisposable;
+		scheduleWithAbsoluteAndState<TState>(state: TState, dueTime: number, action: (scheduler: IScheduler, state: TState) =>IDisposable): IDisposable;
+		scheduleWithRelative(dueTime: number, action: () => void): IDisposable;
+		scheduleWithRelativeAndState<TState>(state: TState, dueTime: number, action: (scheduler: IScheduler, state: TState) =>IDisposable): IDisposable;
+
+		scheduleRecursive(action: (action: () =>void ) =>void ): IDisposable;
+		scheduleRecursiveWithState<TState>(state: TState, action: (state: TState, action: (state: TState) =>void ) =>void ): IDisposable;
+		scheduleRecursiveWithAbsolute(dueTime: number, action: (action: (dueTime: number) => void) => void): IDisposable;
+		scheduleRecursiveWithAbsoluteAndState<TState>(state: TState, dueTime: number, action: (state: TState, action: (state: TState, dueTime: number) => void) => void): IDisposable;
+		scheduleRecursiveWithRelative(dueTime: number, action: (action: (dueTime: number) =>void ) =>void ): IDisposable;
+		scheduleRecursiveWithRelativeAndState<TState>(state: TState, dueTime: number, action: (state: TState, action: (state: TState, dueTime: number) =>void ) =>void ): IDisposable;
+
+		schedulePeriodic(period: number, action: () => void): IDisposable;
+		schedulePeriodicWithState<TState>(state: TState, period: number, action: (state: TState) => TState): IDisposable;
+	}
+
+	export class Scheduler implements IScheduler {
+		constructor(
+			now: () => number,
+			schedule: (state: any, action: (scheduler: IScheduler, state: any) => IDisposable) => IDisposable,
+			scheduleRelative: (state: any, dueTime: number, action: (scheduler: IScheduler, state: any) => IDisposable) => IDisposable,
+			scheduleAbsolute: (state: any, dueTime: number, action: (scheduler: IScheduler, state: any) => IDisposable) => IDisposable);
+
+		static normalize(timeSpan: number): number;
+
+		static immediate: IScheduler;
+		static currentThread: ICurrentThreadScheduler;
+		static timeout: IScheduler;
+
+		now(): number;
+		catch(handler: (exception: any) => boolean): IScheduler;
+		catchException(handler: (exception: any) => boolean): IScheduler;
+
+		schedule(action: () => void): IDisposable;
+		scheduleWithState<TState>(state: TState, action: (scheduler: IScheduler, state: TState) => IDisposable): IDisposable;
+		scheduleWithAbsolute(dueTime: number, action: () => void): IDisposable;
+		scheduleWithAbsoluteAndState<TState>(state: TState, dueTime: number, action: (scheduler: IScheduler, state: TState) => IDisposable): IDisposable;
+		scheduleWithRelative(dueTime: number, action: () => void): IDisposable;
+		scheduleWithRelativeAndState<TState>(state: TState, dueTime: number, action: (scheduler: IScheduler, state: TState) => IDisposable): IDisposable;
+
+		scheduleRecursive(action: (action: () => void) => void): IDisposable;
+		scheduleRecursiveWithState<TState>(state: TState, action: (state: TState, action: (state: TState) => void) => void): IDisposable;
+		scheduleRecursiveWithAbsolute(dueTime: number, action: (action: (dueTime: number) => void) => void): IDisposable;
+		scheduleRecursiveWithAbsoluteAndState<TState>(state: TState, dueTime: number, action: (state: TState, action: (state: TState, dueTime: number) => void) => void): IDisposable;
+		scheduleRecursiveWithRelative(dueTime: number, action: (action: (dueTime: number) => void) => void): IDisposable;
+		scheduleRecursiveWithRelativeAndState<TState>(state: TState, dueTime: number, action: (state: TState, action: (state: TState, dueTime: number) => void) => void): IDisposable;
+
+		schedulePeriodic(period: number, action: () => void): IDisposable;
+		schedulePeriodicWithState<TState>(state: TState, period: number, action: (state: TState) => TState): IDisposable;
+	}
+
+	// Current Thread IScheduler
+	interface ICurrentThreadScheduler extends IScheduler {
+		scheduleRequired(): boolean;
+		ensureTrampoline(action: () =>IDisposable): IDisposable;
+	}
+
+	// Notifications
+	export class Notification<T> {
+		accept(observer: Observer<T>): void;
+		accept<TResult>(onNext: (value: T) => TResult, onError?: (exception: any) => TResult, onCompleted?: () => TResult): TResult;
+		toObservable(scheduler?: IScheduler): Observable<T>;
+		hasValue: boolean;
+		equals(other: Notification<T>): boolean;
+		kind: string;
+		value: T;
+		exception: any;
+
+		static createOnNext<T>(value: T): Notification<T>;
+		static createOnError<T>(exception: any): Notification<T>;
+		static createOnCompleted<T>(): Notification<T>;
+	}
+
+	// Observer
+	export class Observer<T> {
+		onNext(value: T): void;
+		onError(exception: any): void;
+		onCompleted(): void;
+
+		toNotifier(): (notification: Notification<T>) =>void;
+		asObserver(): Observer<T>;
+		checked(): Observer<any>;
+
+		static create<T>(onNext?: (value: T) => void, onError?: (exception: any) => void, onCompleted?: () => void): Observer<T>;
+		static fromNotifier<T>(handler: (notification: Notification<T>) => void): Observer<T>;
+	}
+
+	export interface Observable<T> {
+		subscribe(observer: Observer<T>): IDisposable;
+		subscribe(onNext?: (value: T) => void, onError?: (exception: any) => void, onCompleted?: () => void): IDisposable;
+
+		toArray(): Observable<T[]>;
+
+		observeOn(scheduler: IScheduler): Observable<T>;
+		subscribeOn(scheduler: IScheduler): Observable<T>;
+
+		amb(rightSource: Observable<T>): Observable<T>;
+		catch(handler: (exception: any) => Observable<T>): Observable<T>;
+		catchException(handler: (exception: any) => Observable<T>): Observable<T>;	// alias for catch
+		catch(second: Observable<T>): Observable<T>;
+		catchException(second: Observable<T>): Observable<T>;	// alias for catch
+		combineLatest<T2, TResult>(second: Observable<T2>, resultSelector: (v1: T, v2: T2) => TResult): Observable<TResult>;
+		combineLatest<T2, T3, TResult>(second: Observable<T2>, third: Observable<T3>, resultSelector: (v1: T, v2: T2, v3: T3) => TResult): Observable<TResult>;
+		combineLatest<T2, T3, T4, TResult>(second: Observable<T2>, third: Observable<T3>, fourth: Observable<T4>, resultSelector: (v1: T, v2: T2, v3: T3, v4: T4) => TResult): Observable<TResult>;
+		combineLatest<T2, T3, T4, T5, TResult>(second: Observable<T2>, third: Observable<T3>, fourth: Observable<T4>, fifth: Observable<T5>, resultSelector: (v1: T, v2: T2, v3: T3, v4: T4, v5: T5) => TResult): Observable<TResult>;
+		combineLatest<TOther, TResult>(souces: Observable<TOther>[], resultSelector: (firstValue: T, ...otherValues: TOther[]) => TResult): Observable<TResult>;
+		concat(...sources: Observable<T>[]): Observable<T>;
+		concat(sources: Observable<T>[]): Observable<T>;
+		concatAll(): T;
+		concatObservable(): T;	// alias for concatAll
+		merge(maxConcurrent: number): Observable<T>;
+		merge(other: Observable<T>): Observable<T>;
+		mergeAll(): T;
+		mergeObservable(): T;	// alias for mergeAll
+		onErrorResumeNext(second: Observable<T>): Observable<T>;
+		skipUntil<T2>(other: Observable<T2>): Observable<T>;
+		switchLatest(): T;
+		takeUntil<T2>(other: Observable<T2>): Observable<T>;
+		zip<T2, TResult>(second: Observable<T2>, resultSelector: (v1: T, v2: T2) => TResult): Observable<TResult>;
+		zip<T2, T3, TResult>(second: Observable<T2>, third: Observable<T3>, resultSelector: (v1: T, v2: T2, v3: T3) => TResult): Observable<TResult>;
+		zip<T2, T3, T4, TResult>(second: Observable<T2>, third: Observable<T3>, fourth: Observable<T4>, resultSelector: (v1: T, v2: T2, v3: T3, v4: T4) => TResult): Observable<TResult>;
+		zip<T2, T3, T4, T5, TResult>(second: Observable<T2>, third: Observable<T3>, fourth: Observable<T4>, fifth: Observable<T5>, resultSelector: (v1: T, v2: T2, v3: T3, v4: T4, v5: T5) => TResult): Observable<TResult>;
+		zip<TOther, TResult>(second: Observable<TOther>[], resultSelector: (left: T, right: Observable<TOther>) => TResult): Observable<TResult>;
+		asObservable(): Observable<T>;
+		bufferWithCount(count: number, skip?: number): Observable<T[]>;
+		dematerialize<TOrigin>(): Observable<TOrigin>;
+		distinctUntilChanged(skipParameter: boolean, comparer: (x: T, y: T) => boolean): Observable<T>;
+		distinctUntilChanged<TValue>(keySelector?: (value: T) => TValue, comparer?: (x: TValue, y: TValue) => boolean): Observable<T>;
+		do(observer: Observer<T>): Observable<T>;
+		doAction(observer: Observer<T>): Observable<T>;	// alias for do
+		do(onNext?: (value: T) => void, onError?: (exception: any) => void, onCompleted?: () => void): Observable<T>;
+		doAction(onNext?: (value: T) => void, onError?: (exception: any) => void, onCompleted?: () => void): Observable<T>;	// alias for do
+		finally(action: () => void): Observable<T>;
+		finallyAction(action: () => void): Observable<T>;	// alias for finally
+		ignoreElements(): Observable<T>;
+		materialize(): Observable<Notification<T>>;
+		repeat(repeatCount?: number): Observable<T>;
+		retry(retryCount?: number): Observable<T>;
+		scan<TAcc>(seed: TAcc, accumulator: (acc: TAcc, value: T) => TAcc): Observable<TAcc>;
+		scan(accumulator: (acc: T, value: T) => T): Observable<T>;
+		skipLast(count: number): Observable<T>;
+		startWith(...values: T[]): Observable<T>;
+		startWith(scheduler: IScheduler, ...values: T[]): Observable<T>;
+		takeLast(count: number, scheduler?: IScheduler): Observable<T>;
+		takeLastBuffer(count: number): Observable<T[]>;
+		windowWithCount(count: number, skip?: number): Observable<Observable<T>>;
+		defaultIfEmpty(defaultValue?: T): Observable<T>;
+		distinct(skipParameter: boolean, valueSerializer: (value: T) => string): Observable<T>;
+		distinct<TKey>(keySelector?: (value: T) => TKey, keySerializer?: (key: TKey) => string): Observable<T>;
+		groupBy<TKey, TElement>(keySelector: (value: T) => TKey, skipElementSelector?: boolean, keySerializer?: (key: TKey) => string): Observable<GroupedObservable<TKey, T>>;
+		groupBy<TKey, TElement>(keySelector: (value: T) => TKey, elementSelector: (value: T) => TElement, keySerializer?: (key: TKey) => string): Observable<GroupedObservable<TKey, T>>;
+		groupByUntil<TKey, TDuration>(keySelector: (value: T) => TKey, skipElementSelector: boolean, durationSelector: (group: GroupedObservable<TKey, T>) => Observable<TDuration>, keySerializer?: (key: TKey) => string): Observable<GroupedObservable<TKey, T>>;
+		groupByUntil<TKey, TElement, TDuration>(keySelector: (value: T) => TKey, elementSelector: (value: T) => TElement, durationSelector: (group: GroupedObservable<TKey, TElement>) => Observable<TDuration>, keySerializer?: (key: TKey) => string): Observable<GroupedObservable<TKey, TElement>>;
+		select<TResult>(selector: (value: T, index: number, source: Observable<T>) => TResult, thisArg?: any): Observable<TResult>;
+		map<TResult>(selector: (value: T, index: number, source: Observable<T>) => TResult, thisArg?: any): Observable<TResult>;	// alias for select
+		selectMany<TOther, TResult>(selector: (value: T) => Observable<TOther>, resultSelector: (item: T, other: TOther) => TResult): Observable<TResult>;
+		selectMany<TResult>(selector: (value: T) => Observable<TResult>): Observable<TResult>;
+		selectMany<TResult>(other: Observable<TResult>): Observable<TResult>;
+		flatMap<TOther, TResult>(selector: (value: T) => Observable<TOther>, resultSelector: (item: T, other: TOther) => TResult): Observable<TResult>;	// alias for selectMany
+		flatMap<TResult>(selector: (value: T) => Observable<TResult>): Observable<TResult>;	// alias for selectMany
+		flatMap<TResult>(other: Observable<TResult>): Observable<TResult>;	// alias for selectMany
+		skip(count: number): Observable<T>;
+		skipWhile(predicate: (value: T, index: number, source: Observable<T>) => boolean, thisArg?: any): Observable<T>;
+		take(count: number, scheduler?: IScheduler): Observable<T>;
+		takeWhile(predicate: (value: T, index: number, source: Observable<T>) => boolean, thisArg?: any): Observable<T>;
+		where(predicate: (value: T, index: number, source: Observable<T>) => boolean, thisArg?: any): Observable<T>;
+		filter(predicate: (value: T, index: number, source: Observable<T>) => boolean, thisArg?: any): Observable<T>; // alias for where
+	}
+
+	interface ObservableStatic {
+		create<T>(subscribe: (observer: Observer<T>) => void): Observable<T>;
+		create<T>(subscribe: (observer: Observer<T>) => () => void): Observable<T>;
+		createWithDisposable<T>(subscribe: (observer: Observer<T>) => IDisposable): Observable<T>;
+		defer<T>(observableFactory: () => Observable<T>): Observable<T>;
+		empty<T>(scheduler?: IScheduler): Observable<T>;
+		fromArray<T>(array: T[], scheduler?: IScheduler): Observable<T>;
+		fromArray<T>(array: { length: number;[index: number]: T; }, scheduler?: IScheduler): Observable<T>;
+		generate<TState, TResult>(initialState: TState, condition: (state: TState) => boolean, iterate: (state: TState) => TState, resultSelector: (state: TState) => TResult, scheduler?: IScheduler): Observable<TResult>;
+		never<T>(): Observable<T>;
+		range(start: number, count: number, scheduler?: IScheduler): Observable<number>;
+		repeat<T>(value: T, repeatCount?: number, scheduler?: IScheduler): Observable<T>;
+		return<T>(value: T, scheduler?: IScheduler): Observable<T>;
+		returnValue<T>(value: T, scheduler?: IScheduler): Observable<T>;	// alias for return
+		throw<T>(exception: Error, scheduler?: IScheduler): Observable<T>;
+		throw<T>(exception: any, scheduler?: IScheduler): Observable<T>;
+		throwException<T>(exception: Error, scheduler?: IScheduler): Observable<T>;	// alias for throw
+		throwException<T>(exception: any, scheduler?: IScheduler): Observable<T>;	// alias for throw
+		using<TSource, TResource extends IDisposable>(resourceFactory: () => TResource, observableFactory: (resource: TResource) => Observable<TSource>): Observable<TSource>;
+		amb<T>(...sources: Observable<T>[]): Observable<T>;
+		amb<T>(sources: Observable<T>[]): Observable<T>;
+		catch<T>(sources: Observable<T>[]): Observable<T>;
+		catchException<T>(sources: Observable<T>[]): Observable<T>;	// alias for catch
+		catch<T>(...sources: Observable<T>[]): Observable<T>;
+		catchException<T>(...sources: Observable<T>[]): Observable<T>;	// alias for catch
+		concat<T>(...sources: Observable<T>[]): Observable<T>;
+		concat<T>(sources: Observable<T>[]): Observable<T>;
+		merge<T>(...sources: Observable<T>[]): Observable<T>;
+		merge<T>(sources: Observable<T>[]): Observable<T>;
+		merge<T>(scheduler: IScheduler, ...sources: Observable<T>[]): Observable<T>;
+		merge<T>(scheduler: IScheduler, sources: Observable<T>[]): Observable<T>;
+		onErrorResumeNext<T>(...sources: Observable<T>[]): Observable<T>;
+		onErrorResumeNext<T>(sources: Observable<T>[]): Observable<T>;
+		zip<T1, T2, TResult>(first: Observable<T1>, sources: Observable<T2>[], resultSelector: (item1: T1, right: Observable<T2>) => TResult): Observable<TResult>;
+		zip<T1, T2, TResult>(source1: Observable<T1>, source2: Observable<T2>, resultSelector: (item1: T1, item2: T2) => TResult): Observable<TResult>;
+		zip<T1, T2, T3, TResult>(source1: Observable<T1>, source2: Observable<T2>, source3: Observable<T3>, resultSelector: (item1: T1, item2: T2, item3: T3) => TResult): Observable<TResult>;
+		zip<T1, T2, T3, T4, TResult>(source1: Observable<T1>, source2: Observable<T2>, source3: Observable<T3>, source4: Observable<T4>, resultSelector: (item1: T1, item2: T2, item3: T3, item4: T4) => TResult): Observable<TResult>;
+		zip<T1, T2, T3, T4, T5, TResult>(source1: Observable<T1>, source2: Observable<T2>, source3: Observable<T3>, source4: Observable<T4>, source5: Observable<T5>, resultSelector: (item1: T1, item2: T2, item3: T3, item4: T4, item5: T5) => TResult): Observable<TResult>;
+		zipArray<T>(...sources: Observable<T>[]): Observable<T[]>;
+		zipArray<T>(sources: Observable<T>[]): Observable<T[]>;
+	}
+
+	export var Observable: ObservableStatic;
+
+	interface GroupedObservable<TKey, TElement> extends Observable<TElement> {
+		key: TKey;
+		underlyingObservable: Observable<TElement>;
+	}
+
+	interface ISubject<T> extends Observable<T>, Observer<T>, IDisposable {
+		hasObservers(): boolean;
+	}
+
+    export interface Subject<T> extends ISubject<T> {
     }
 
-    //Collections
-    interface IIndexedItem {
-        id: number;
-        value: IScheduledItem;
+    interface SubjectStatic {
+        new <T>(): Subject<T>;
+		create<T>(observer?: Observer<T>, observable?: Observable<T>): ISubject<T>;
+	}
 
-        compareTo(other: IIndexedItem): number;
-    }
+	export var Subject: SubjectStatic;
 
-    // Priority Queue for Scheduling
-    interface IPriorityQueue {
-        items: IIndexedItem[];
-        length: number;
+	export interface AsyncSubject<T> extends Subject<T> {
+	}
 
-        isHigherPriority(left: number, right: number): boolean;
-        percolate(index: number): void;
-        heapify(index: number): void;
-        peek(): IIndexedItem;
-        removeAt(index: number): void;
-        dequeue(): IIndexedItem;
-        enqueue(item: IIndexedItem): void;
-        remove(item: IIndexedItem): boolean;
-    }
+	interface AsyncSubjectStatic {
+		new <T>(): AsyncSubject<T>;
+	}
 
-    interface _IDisposable {
-        dispose(): void;
-    }
-
-    interface ICompositeDisposable {
-        disposables: _IDisposable[];
-        isDisposed: boolean;
-        length: number;
-
-        dispose(): void;
-        add(item: _IDisposable): void;
-        remove(item: _IDisposable): boolean;
-        clear(): void;
-        contains(item: _IDisposable): boolean;
-        toArray(): _IDisposable[];
-    }
-    export module CompositeDisposable {
-        function new (...disposables: _IDisposable[]): ICompositeDisposable;
-    }
-
-    // Main disposable class
-    interface IDisposable {
-        isDisposed: boolean;
-        action: () =>void;
-
-        dispose(): void;
-    }
-    export module Disposable {
-        function new (action: () =>void ): IDisposable;
-
-        function create(action: () =>void ): _IDisposable;
-        var empty: _IDisposable;
-    }
-
-    // Single assignment
-    interface ISingleAssignmentDisposable {
-        isDisposed: boolean;
-        current: _IDisposable;
-
-        dispose(): void;
-        disposable(value?: _IDisposable): _IDisposable;
-        getDisposable(): _IDisposable;
-        setDisposable(value: _IDisposable): void;
-    }
-    export module SingleAssignmentDisposable {
-        function new (): ISingleAssignmentDisposable;
-    }
-
-    // Multiple assignment disposable
-    interface ISerialDisposable {
-        isDisposed: boolean;
-        current: _IDisposable;
-
-        dispose(): void;
-        getDisposable(): _IDisposable;
-        setDisposable(value: _IDisposable): void;
-        disposable(value?: _IDisposable): _IDisposable;
-    }
-    export module SerialDisposable {
-        function new (): ISerialDisposable;
-    }
-
-    interface IRefCountDisposable {
-        underlyingDisposable: _IDisposable;
-        isDisposed: boolean;
-        isPrimaryDisposed: boolean;
-        count: number;
-
-        dispose(): void;
-        getDisposable(): _IDisposable;
-    }
-    export module RefCountDisposable {
-        function new (disposable: _IDisposable): IRefCountDisposable;
-    }
-
-    interface IScheduledItem {
-        scheduler: IScheduler;
-        state: any;
-        action: (scheduler: IScheduler, state) => _IDisposable;
-        dueTime: number;
-        comparer: (x: number, y: number) =>number;
-        disposable: ISingleAssignmentDisposable;
-
-        invoke(): void;
-        compareTo(other: IScheduledItem): number;
-        isCancelled(): boolean;
-        invokeCore(): _IDisposable;
-    }
-
-    interface IScheduler {
-        _schedule: (state: any, action: (scheduler: IScheduler, state: any) =>_IDisposable) => _IDisposable;
-        _scheduleRelative: (state: any, dueTime: number, action: (scheduler: IScheduler, state: any) =>_IDisposable) =>_IDisposable;
-        _scheduleAbsolute: (state: any, dueTime: number, action: (scheduler: IScheduler, state: any) =>_IDisposable) =>_IDisposable;
-
-        now(): number;
-        scheduleWithState(state: any, action: (scheduler: IScheduler, state: any) =>_IDisposable): _IDisposable;
-        scheduleWithAbsoluteAndState(state: any, dueTime: number, action: (scheduler: IScheduler, state: any) =>_IDisposable): _IDisposable;
-        scheduleWithRelativeAndState(state: any, dueTime: number, action: (scheduler: IScheduler, state: any) =>_IDisposable): _IDisposable;
-
-        catchException(handler: (exception: any) =>bool): ICatchScheduler;
-        schedulePeriodic(period: number, action: () =>void ): _IDisposable;
-        schedulePeriodicWithState(state: any, period: number, action: (state: any) =>any): _IDisposable;//returns {Disposable|SingleAssignmentDisposable}
-        schedule(action: () =>void ): _IDisposable;
-        scheduleWithRelative(dueTime: number, action: () =>void ): _IDisposable;
-        scheduleWithAbsolute(dueTime: number, action: () =>void ): _IDisposable;
-        scheduleRecursive(action: (action: () =>void ) =>void ): _IDisposable;
-        scheduleRecursiveWithState(state: any, action: (state: any, action: (state: any) =>void ) =>void ): _IDisposable;
-        scheduleRecursiveWithRelative(dueTime: number, action: (action: (dueTime: number) =>void ) =>void ): _IDisposable;
-        scheduleRecursiveWithRelativeAndState(state: any, dueTime: number, action: (state: any, action: (state: any, dueTime: number) =>void ) =>void ): _IDisposable;
-        scheduleRecursiveWithAbsolute(dueTime: number, action: (action: (dueTime: number) =>void ) =>void ): _IDisposable;
-        scheduleRecursiveWithAbsoluteAndState(state: any, dueTime: number, action: (state: any, action: (state: any, dueTime: number) =>void ) =>void ): _IDisposable;
-    }
-    export module Scheduler {
-        function new (now: () =>number,
-            schedule: (state: any, action: (scheduler: IScheduler, state: any) =>_IDisposable) => _IDisposable,
-            scheduleRelative: (state: any, dueTime: number, action: (scheduler: IScheduler, state: any) =>_IDisposable) =>_IDisposable,
-            scheduleAbsolute: (state: any, dueTime: number, action: (scheduler: IScheduler, state: any) =>_IDisposable) =>_IDisposable
-            ): IScheduler;
-
-        function now(): number;
-        function normalize(timeSpan: number): number;
-
-        var immediate: IScheduler;
-        var currentThread: ICurrentScheduler;//IScheduler;
-        var timeout: IScheduler;
-    }
-
-    // Current Thread IScheduler
-    interface ICurrentScheduler extends IScheduler {
-        scheduleRequired(): boolean;
-        ensureTrampoline(action: () =>_IDisposable): _IDisposable;
-    }
-
-    // Virtual IScheduler
-    interface IVirtualTimeScheduler extends IScheduler {
-        toRelative(duetime): number;
-        toDateTimeOffset(duetime: number): number;
-
-        clock: number;
-        comparer: (x: number, y: number) =>number;
-        isEnabled: boolean;
-        queue: IPriorityQueue;
-        scheduleRelativeWithState(state: any, dueTime: number, action: (scheduler: IScheduler, state: any) =>_IDisposable): _IDisposable;
-        scheduleRelative(dueTime: number, action: () =>void ): _IDisposable;
-        start(): _IDisposable;
-        stop(): void;
-        advanceTo(time: number);
-        advanceBy(time: number);
-        sleep(time: number);
-        getNext(): IScheduledItem;
-        scheduleAbsolute(dueTime: number, action: () =>void );
-        scheduleAbsoluteWithState(state: any, dueTime: number, action: (scheduler: IScheduler, state: any) =>_IDisposable): _IDisposable;
-    }
-    //export module VirtualTimeScheduler {
-    //    //absract
-    //    function new (initialClock: number, comparer: (x: number, y: number) =>number): IVirtualTimeScheduler;
-    //}
-
-
-    // CatchScheduler
-    interface ICatchScheduler extends IScheduler { }
-
-    // Notifications
-    interface INotification {
-        accept(observer: IObserver): void;
-        accept(onNext: (value: any) =>void , onError?: (exception: any) =>void , onCompleted?: () =>void ): void;
-        toObservable(scheduler?: IScheduler): IObservable;
-        hasValue: boolean;
-        equals(other: INotification): boolean;
-    }
-    export module Notification {
-        //absctract
-        //function new (): INotification;
-
-        function createOnNext(value: any): INotification;//ON
-        function createOnError(exception): INotification;//OE
-        function createOnCompleted(): INotification;//OC
-    }
-
-    export module  Internals {
-        // Enumerator
-        interface IEnumerator {
-            moveNext(): boolean;
-            getCurrent(): any;
-            dispose(): void;
-        }
-        export module Enumerator {
-            function new (moveNext: () =>bool, getCurrent: () => any, dispose: () =>void ): IEnumerator;
-
-            function create(moveNext: () =>bool, getCurrent: () =>any, dispose?: () =>void ): IEnumerator;
-        }
-
-        // Enumerable
-        interface IEnumerable {
-            getEnumerator(): IEnumerator;
-
-            concat(): IObservable;
-            catchException(): IObservable;
-        }
-        export module Enumerable {
-            function new (getEnumerator: () =>IEnumerator): IEnumerable;
-
-            function repeat(value: any, repeatCount?: number): IEnumerable;
-            function forEach(source: any[], selector?: (element: any, index: number) =>any): IEnumerable;
-            function forEach(source: { length: number;[index: number]: any; }, selector?: (element: any, index: number) =>any): IEnumerable;
-        }
-    }
-
-    // Observer
-    interface IObserver {
-        onNext(value: any): void;
-        onError(exception: any): void;
-        onCompleted(): void;
-
-        toNotifier(): (notification: INotification) =>void;
-        asObserver(): IObserver;
-        checked(): ICheckedObserver;
-    }
-    export module Observer {
-        //abstract
-        //function new (): IObserver;
-
-        function create(onNext: (value: any) =>void , onError?: (exception: any) =>void , onCompleted?: () =>void ): IObserver;
-        function fromNotifier(handler: (notification: INotification) =>void ): IObserver;
-    }
-
-    export module Internals {
-        // Abstract Observer
-        interface IAbstractObserver extends IObserver {
-            isStopped: boolean;
-
-            dispose(): void;
-            next(value: any): void;
-            error(exception: any): void;
-            completed(): void;
-            fail(): boolean;
-        }
-        //export module AbstractObserver {
-        //    //abstract
-        //    function new (): IAbstractObserver;
-        //}
-    }
-
-    interface IAnonymousObserver extends Internals.IAbstractObserver {
-        _onNext: (value: any) =>void;
-        _onError: (exception: any) =>void;
-        _onCompleted: () =>void;
-    }
-    export module AnonymousObserver {
-        function new (onNext: (value: any) =>void , onError: (exception: any) =>void , onCompleted: () =>void ): IAnonymousObserver;
-    }
-
-    interface ICheckedObserver extends IObserver {
-        _observer: IObserver;
-        _state: number; // 0 - idle, 1 - busy, 2 - done
-        checkAccess(): void;
-    }
-
-    export module Internals {
-        interface IScheduledObserver extends IAbstractObserver {
-            scheduler: IScheduler;
-            observer: IObserver;
-            isAcquired: boolean;
-            hasFaulted: boolean;
-            queue: { (value: any): void; (exception: any): void; (): void; }[];
-            disposable: ISerialDisposable;
-
-            ensureActive(): void;
-        }
-        export module ScheduledObserver {
-            function new (scheduler: IScheduler, observer: IObserver): IScheduledObserver;
-        }
-    }
-
-
-    interface IObservable {
-        _subscribe: (observer: IObserver) =>_IDisposable;
-
-        subscribe(observer: IObserver): _IDisposable;
-
-        finalValue(): IObservable;
-        subscribe(onNext?: (value: any) =>void , onError?: (exception: any) =>void , onCompleted?: () =>void ): _IDisposable;
-        toArray(): IObservable;
-
-        observeOn(scheduler: IScheduler): IObservable;
-        subscribeOn(scheduler: IScheduler): IObservable;
-        amb(rightSource: IObservable): IObservable;
-        catchException(handler: (exception: any) =>IObservable): IObservable;
-        catchException(second: IObservable): IObservable;
-        combineLatest(second: IObservable, resultSelector: (v1: any, v2: any) =>any): IObservable;
-        combineLatest(second: IObservable, third: IObservable, resultSelector: (v1: any, v2: any, v3: any) =>any): IObservable;
-        combineLatest(second: IObservable, third: IObservable, fourth: IObservable, resultSelector: (v1: any, v2: any, v3: any, v4: any) =>any): IObservable;
-        combineLatest(second: IObservable, third: IObservable, fourth: IObservable, fifth, IObservable, resultSelector: (v1: any, v2: any, v3: any, v4: any, v5: any) =>any): IObservable;
-        combineLatest(...soucesAndResultSelector: any[]): IObservable;
-        concat(...sources: IObservable[]): IObservable;
-        concat(sources: IObservable[]): IObservable;
-        concatIObservable(): IObservable;
-        merge(maxConcurrent: number): IObservable;
-        merge(other: IObservable): IObservable;
-        mergeIObservable(): IObservable;
-        onErrorResumeNext(second: IObservable): IObservable;
-        skipUntil(other: IObservable): IObservable;
-        switchLatest(): IObservable;
-        takeUntil(other: IObservable): IObservable;
-        zip(second: IObservable, resultSelector: (v1: any, v2: any) =>any): IObservable;
-        zip(second: IObservable, third: IObservable, resultSelector: (v1: any, v2: any, v3: any) =>any): IObservable;
-        zip(second: IObservable, third: IObservable, fourth: IObservable, resultSelector: (v1: any, v2: any, v3: any, v4: any) =>any): IObservable;
-        zip(second: IObservable, third: IObservable, fourth: IObservable, fifth, IObservable, resultSelector: (v1: any, v2: any, v3: any, v4: any, v5: any) =>any): IObservable;
-        zip(...soucesAndResultSelector: any[]): IObservable;
-        zip(second: any[], resultSelector: (left: any, right: any) =>any): IObservable;
-        asIObservable(): IObservable;
-        bufferWithCount(count: number, skip?: number): IObservable;
-        dematerialize(): IObservable;
-        distinctUntilChanged(keySelector?: (value: any) =>any, comparer?: (x: any, y: any) =>bool): IObservable;
-        doAction(observer: IObserver): IObservable;
-        doAction(onNext: (value: any) => void , onError?: (exception: any) =>void , onCompleted?: () =>void ): IObservable;
-        finallyAction(action: () =>void ): IObservable;
-        ignoreElements(): IObservable;
-        materialize(): IObservable;
-        repeat(repeatCount?: number): IObservable;
-        retry(retryCount?: number): IObservable;
-        scan(seed: number, accumulator: (acc: any, value: any) =>any): IObservable;
-        scan(accumulator: (acc: any, value: any) =>any): IObservable;
-        skipLast(count: number): IObservable;
-        startWith(...values: any[]): IObservable;
-        startWith(scheduler: IScheduler, ...values: any[]): IObservable;
-        takeLast(count: number, scheduler?: IScheduler): IObservable;
-        takeLastBuffer(count: number): IObservable;
-        windowWithCount(count: number, skip?: number): IObservable;
-        defaultIfEmpty(defaultValue?: any): IObservable;
-        distinct(keySelector?: (value: any) =>any, keySerializer?: (key: any) =>string): IObservable;
-        groupBy(keySelector: (value: any) =>any, elementSelector?: (value: any) =>any, keySerializer?: (key: any) =>string): IGroupedObservable;
-        groupByUntil(keySelector: (value: any) =>any, elementSelector: (value: any) =>any, durationSelector: (gloup: IGroupedObservable) =>IObservable, keySerializer?: (key: any) =>string): IGroupedObservable;
-        select(selector: (value: any, index: number) =>any): IObservable;
-        selectMany(selector: (value: any) =>IObservable, resultSelector?: (x: any, y: any) =>any): IObservable;
-        selectMany(other: IObservable): IObservable;
-        skip(count: number): IObservable;
-        skipWhile(predicate: (value: any, index?: number) =>bool): IObservable;
-        take(count: number, scheduler?: IScheduler): IObservable;
-        takeWhile(predicate: (value: any, index?: number) =>bool): IObservable;
-        where(predicate: (value: any, index?: number) =>bool): IObservable;
-    }
-    export module Observable {
-        function new (subscribe: (observer: IObserver) =>_IDisposable): IObservable;
-
-        function start(func: () =>any, scheduler?: IScheduler, context?: any): IObservable;
-        function toAsync(func: Function, scheduler?: IScheduler, context?: any): (...arguments: any[]) => IObservable;
-        function create(subscribe: (Observer) =>() =>void ): IObservable;
-        function createWithDisposable(subscribe: (Observer) =>_IDisposable): IObservable;
-        function defer(observableFactory: () =>IObservable): IObservable;
-        function empty(scheduler?: IScheduler): IObservable;
-        function fromArray(array: any[], scheduler?: IScheduler): IObservable;
-        function fromArray(array: { length: number;[index: number]: any; }, scheduler?: IScheduler): IObservable;
-        function generate(initialState: any, condition: (state: any) =>bool, iterate: (state: any) =>any, resultSelector: (state: any) =>any, scheduler?: IScheduler): IObservable;
-        function never(): IObservable;
-        function range(start: number, count: number, scheduler?: IScheduler): IObservable;
-        function repeat(value: any, repeatCount?: number, scheduler?: IScheduler): IObservable;
-        function returnValue(value: any, scheduler?: IScheduler): IObservable;
-        function throwException(exception: any, scheduler?: IScheduler): IObservable;
-        function using(resourceFactory: () =>any, observableFactory: (resource: any) =>IObservable): IObservable;
-        function amb(...sources: IObservable[]): IObservable;
-        function catchException(sources: IObservable[]): IObservable;
-        function catchException(...sources: IObservable[]): IObservable;
-        function concat(...sources: IObservable[]): IObservable;
-        function concat(sources: IObservable[]): IObservable;
-        function merge(...sources: IObservable[]): IObservable;
-        function merge(sources: IObservable[]): IObservable;
-        function merge(scheduler: IScheduler, ...sources: IObservable[]): IObservable;
-        function merge(scheduler: IScheduler, sources: IObservable[]): IObservable;
-        function onErrorResumeNext(...sources: IObservable[]): IObservable;
-        function onErrorResumeNext(sources: IObservable[]): IObservable;
-    }
-
-    export module Internals {
-        interface IAnonymousObservable extends IObservable { }
-        export module AnonymousObservable {
-            function new (subscribe: (observer: IObserver) =>_IDisposable): IAnonymousObservable;
-        }
-    }
-
-    interface IGroupedObservable extends IObservable {
-        key: any;
-        underlyingObservable: IObservable;
-    }
-
-    interface ISubject extends IObservable, IObserver {
-        isDisposed: boolean;
-        isStopped: boolean;
-        observers: IObserver[];
-
-        dispose(): void;
-    }
-    export module Subject {
-        function new (): ISubject;
-
-        function create(observer: IObserver, observable: IObservable): ISubject;
-    }
-
-    interface IAsyncSubject extends IObservable, IObserver {
-        isDisposed: boolean;
-        value: any;
-        hasValue: boolean;
-        observers: IObserver[];
-        exception: any;
-
-        dispose(): void;
-    }
-    export module AsyncSubject {
-        function new (): IAsyncSubject;
-    }
-
-    interface IAnonymousSubject extends IObservable {
-        onNext(value: any): void;
-        onError(exception: any): void;
-        onCompleted(): void;
-    }
+	export var AsyncSubject: AsyncSubjectStatic;
 }

--- a/Source/Chronozoom.UI/ui/auth-edit-collection-form.ts
+++ b/Source/Chronozoom.UI/ui/auth-edit-collection-form.ts
@@ -122,15 +122,15 @@ module CZ {
 
                 this.backgroundInput.val(this.collectionTheme.backgroundUrl);
                 this.mediaList = new CZ.UI.MediaList(this.mediaListContainer, CZ.Media.mediaPickers, this.contentItem, this);
-                this.kioskmodeInput.attr("checked", this.collectionTheme.kioskMode);
+                this.kioskmodeInput.attr("checked", this.collectionTheme.kioskMode.toString());
 
                 if (!this.collectionTheme.timelineColor) this.collectionTheme.timelineColor = CZ.Settings.timelineColorOverride;
                 this.timelineBackgroundColorInput.val(this.getHexColorFromColor(this.collectionTheme.timelineColor));
-                this.timelineBackgroundOpacityInput.val(this.getOpacityFromRGBA(this.collectionTheme.timelineColor));
+                this.timelineBackgroundOpacityInput.val(this.getOpacityFromRGBA(this.collectionTheme.timelineColor).toString());
                 this.timelineBorderColorInput.val(this.getHexColorFromColor(this.collectionTheme.timelineStrokeStyle));
 
                 this.exhibitBackgroundColorInput.val(this.getHexColorFromColor(this.collectionTheme.infoDotFillColor));
-                this.exhibitBackgroundOpacityInput.val(this.getOpacityFromRGBA(this.collectionTheme.infoDotFillColor));
+                this.exhibitBackgroundOpacityInput.val(this.getOpacityFromRGBA(this.collectionTheme.infoDotFillColor).toString());
                 this.exhibitBorderColorInput.val(this.getHexColorFromColor(this.collectionTheme.infoDotBorderColor));
             }
 

--- a/Source/Chronozoom.UI/ui/controls/datepicker.ts
+++ b/Source/Chronozoom.UI/ui/controls/datepicker.ts
@@ -280,7 +280,7 @@ module CZ {
             private setDate_YearMode(coordinate: number, ZeroYearConversation): void {
                 var date = CZ.Dates.convertCoordinateToYear(coordinate);
                 if ((date.regime.toLowerCase() == "bce") && (ZeroYearConversation)) date.year--;
-                this.yearSelector.val(date.year);
+                this.yearSelector.val(date.year.toString());
                 // reset selected regime
                 this.regimeSelector.find(":selected").attr("selected", "false");
 
@@ -298,7 +298,7 @@ module CZ {
             private setDate_DateMode(coordinate: number): void {
                 var date = CZ.Dates.getYMDFromCoordinate(coordinate);
 
-                this.yearSelector.val(date.year);
+                this.yearSelector.val(date.year.toString());
                 var self = this;
 
                 // set corresponding month in month select element

--- a/Source/Chronozoom.UI/ui/header-edit-profile-form.ts
+++ b/Source/Chronozoom.UI/ui/header-edit-profile-form.ts
@@ -78,7 +78,7 @@ module CZ {
                         }
                         this.emailInput.val(data.Email);
                         if (data.Email !== undefined && data.Email !== '' && data.Email != null) {
-                            this.agreeInput.attr('checked', true);
+                            this.agreeInput.attr('checked', 'true');
                             this.agreeInput.prop('disabled', true);
                         }
                     }

--- a/Source/Chronozoom.UI/ui/message-window.ts
+++ b/Source/Chronozoom.UI/ui/message-window.ts
@@ -28,7 +28,7 @@ module CZ {
                     direction: "left",
                     duration: 300,
                     complete: () => {
-                        $(document).on("keyup", this, this.onDocumentKeyPress);                        
+                        $(document).on("keyup", this.onDocumentKeyPress);                        
                     }
                 });
             }


### PR DESCRIPTION
In cz.ts, $(window).bind('resize', ...) handler was hitting a null reference when calling
  timeSeriesChart when no timeSeriesChart was displayed, this was causing the rest of the
  resize handler to be skipped.  Added null check.

Hit multiple issues in TypeScript 0.9.1 (compiler included with VS 2013) and 0.9.5 (currently
  available compiler).  Documented in bugs:
    https://typescript.codeplex.com/workitem/2168
    borisyankov/DefinitelyTyped#1681
  Worked around these by modifying jquery.d.ts after bringing in latest copy from
  https://github.com/borisyankov/DefinitelyTyped/.

Removed post build event to shell out to tsc and instead turned on new VS 2013 feature to auto
compile and merge *.ts into cz.js.
