### PR TITLE
Hotfix - Kiosk Mode Now Defaults to Unchecked

### DIFF
--- a/Source/Chronozoom.UI/cz.js
+++ b/Source/Chronozoom.UI/cz.js
@@ -3137,7 +3137,7 @@ var CZ;
                 _super.call(this, container, listBoxInfo, listItemsInfo);
             }
             return TourStopListBox;
-        })(CZ.UI.ListBoxBase);
+        })(UI.ListBoxBase);
         UI.TourStopListBox = TourStopListBox;
 
         var TourStopListItem = (function (_super) {
@@ -3202,7 +3202,7 @@ var CZ;
                 myDescr.show(500);
             };
             return TourStopListItem;
-        })(CZ.UI.ListItemBase);
+        })(UI.ListItemBase);
         UI.TourStopListItem = TourStopListItem;
     })(CZ.UI || (CZ.UI = {}));
     var UI = CZ.UI;
@@ -5452,7 +5452,7 @@ var CZ;
                 configurable: true
             });
             return TourListBox;
-        })(CZ.UI.ListBoxBase);
+        })(UI.ListBoxBase);
         UI.TourListBox = TourListBox;
 
         var TourListItem = (function (_super) {
@@ -5497,7 +5497,7 @@ var CZ;
                 }
             }
             return TourListItem;
-        })(CZ.UI.ListItemBase);
+        })(UI.ListItemBase);
         UI.TourListItem = TourListItem;
     })(CZ.UI || (CZ.UI = {}));
     var UI = CZ.UI;
@@ -10772,7 +10772,7 @@ var CZ;
                 CZ.Authoring.isActive = false;
                 CZ.Authoring.mode = "editTour";
 
-                CZ.Authoring.showEditTourForm(null);
+                Authoring.showEditTourForm(null);
             }
             UI.createTour = createTour;
 
@@ -13011,7 +13011,7 @@ var CZ;
                 _super.prototype.remove.call(this, item);
             };
             return ContentItemListBox;
-        })(CZ.UI.ListBoxBase);
+        })(UI.ListBoxBase);
         UI.ContentItemListBox = ContentItemListBox;
 
         var ContentItemListItem = (function (_super) {
@@ -13041,7 +13041,7 @@ var CZ;
                 });
             }
             return ContentItemListItem;
-        })(CZ.UI.ListItemBase);
+        })(UI.ListItemBase);
         UI.ContentItemListItem = ContentItemListItem;
     })(CZ.UI || (CZ.UI = {}));
     var UI = CZ.UI;
@@ -13357,8 +13357,8 @@ var CZ;
             };
 
             FormEditExhibit.prototype.close = function (noAnimation) {
-                if (typeof noAnimation === "undefined") { noAnimation = false; }
                 var _this = this;
+                if (typeof noAnimation === "undefined") { noAnimation = false; }
                 if (this.isModified) {
                     if (window.confirm("There is unsaved data. Do you want to close without saving?")) {
                         this.isModified = false;
@@ -13394,7 +13394,7 @@ var CZ;
                 CZ.Common.vc.virtualCanvas("showNonRootVirtualSpace");
             };
             return FormEditExhibit;
-        })(CZ.UI.FormUpdateEntity);
+        })(UI.FormUpdateEntity);
         UI.FormEditExhibit = FormEditExhibit;
     })(CZ.UI || (CZ.UI = {}));
     var UI = CZ.UI;
@@ -13510,7 +13510,7 @@ var CZ;
                     this.titleTextblock.text("Edit");
                     this.saveButton.text("Update Artifact");
 
-                    if (this.prevForm && this.prevForm instanceof CZ.UI.FormEditExhibit)
+                    if (this.prevForm && this.prevForm instanceof UI.FormEditExhibit)
                         this.closeButton.hide();
                     else
                         this.closeButton.show();
@@ -13547,7 +13547,7 @@ var CZ;
 
                 if ((CZ.Authoring.validateContentItems([newContentItem], this.mediaInput)) && (CZ.Authoring.isValidURL(newContentItem.uri))) {
                     if (CZ.Authoring.contentItemMode === "createContentItem") {
-                        if (this.prevForm && this.prevForm instanceof CZ.UI.FormEditExhibit) {
+                        if (this.prevForm && this.prevForm instanceof UI.FormEditExhibit) {
                             this.isCancel = false;
                             this.prevForm.contentItemsListBox.add(newContentItem);
                             $.extend(this.exhibit.contentItems[this.contentItem.order], newContentItem);
@@ -13557,7 +13557,7 @@ var CZ;
                             this.back();
                         }
                     } else if (CZ.Authoring.contentItemMode === "editContentItem") {
-                        if (this.prevForm && this.prevForm instanceof CZ.UI.FormEditExhibit) {
+                        if (this.prevForm && this.prevForm instanceof UI.FormEditExhibit) {
                             this.isCancel = false;
                             var clickedListItem = this.prevForm.clickedListItem;
                             clickedListItem.iconImg.attr("src", newContentItem.uri);
@@ -13615,8 +13615,8 @@ var CZ;
             };
 
             FormEditCI.prototype.close = function (noAnimation) {
-                if (typeof noAnimation === "undefined") { noAnimation = false; }
                 var _this = this;
+                if (typeof noAnimation === "undefined") { noAnimation = false; }
                 if (this.isModified) {
                     if (window.confirm("There is unsaved data. Do you want to close without saving?")) {
                         this.isModified = false;
@@ -13737,7 +13737,7 @@ var CZ;
 
                 this.backgroundInput.val(this.collectionTheme.backgroundUrl);
                 this.mediaList = new CZ.UI.MediaList(this.mediaListContainer, CZ.Media.mediaPickers, this.contentItem, this);
-                this.kioskmodeInput.attr("checked", this.collectionTheme.kioskMode.toString());
+                this.kioskmodeInput.prop('checked', false);
 
                 if (!this.collectionTheme.timelineColor)
                     this.collectionTheme.timelineColor = CZ.Settings.timelineColorOverride;

--- a/Source/Chronozoom.UI/scripts/authoring-ui.js
+++ b/Source/Chronozoom.UI/scripts/authoring-ui.js
@@ -10,7 +10,7 @@
                 CZ.Authoring.isActive = false;
                 CZ.Authoring.mode = "editTour";
 
-                CZ.Authoring.showEditTourForm(null);
+                Authoring.showEditTourForm(null);
             }
             UI.createTour = createTour;
 

--- a/Source/Chronozoom.UI/ui/auth-edit-collection-form.js
+++ b/Source/Chronozoom.UI/ui/auth-edit-collection-form.js
@@ -91,7 +91,7 @@ var CZ;
 
                 this.backgroundInput.val(this.collectionTheme.backgroundUrl);
                 this.mediaList = new CZ.UI.MediaList(this.mediaListContainer, CZ.Media.mediaPickers, this.contentItem, this);
-                this.kioskmodeInput.attr("checked", this.collectionTheme.kioskMode.toString());
+                this.kioskmodeInput.prop('checked', false);
 
                 if (!this.collectionTheme.timelineColor)
                     this.collectionTheme.timelineColor = CZ.Settings.timelineColorOverride;

--- a/Source/Chronozoom.UI/ui/auth-edit-collection-form.ts
+++ b/Source/Chronozoom.UI/ui/auth-edit-collection-form.ts
@@ -122,7 +122,7 @@ module CZ {
 
                 this.backgroundInput.val(this.collectionTheme.backgroundUrl);
                 this.mediaList = new CZ.UI.MediaList(this.mediaListContainer, CZ.Media.mediaPickers, this.contentItem, this);
-                this.kioskmodeInput.attr("checked", this.collectionTheme.kioskMode.toString());
+                this.kioskmodeInput.prop('checked', false); // temp default to false for now until fix in place that loads theme from db (full fix implemented in MultiUser branch)
 
                 if (!this.collectionTheme.timelineColor) this.collectionTheme.timelineColor = CZ.Settings.timelineColorOverride;
                 this.timelineBackgroundColorInput.val(this.getHexColorFromColor(this.collectionTheme.timelineColor));

--- a/Source/Chronozoom.UI/ui/auth-edit-contentitem-form.js
+++ b/Source/Chronozoom.UI/ui/auth-edit-contentitem-form.js
@@ -115,7 +115,7 @@ var CZ;
                     this.titleTextblock.text("Edit");
                     this.saveButton.text("Update Artifact");
 
-                    if (this.prevForm && this.prevForm instanceof CZ.UI.FormEditExhibit)
+                    if (this.prevForm && this.prevForm instanceof UI.FormEditExhibit)
                         this.closeButton.hide();
                     else
                         this.closeButton.show();
@@ -152,7 +152,7 @@ var CZ;
 
                 if ((CZ.Authoring.validateContentItems([newContentItem], this.mediaInput)) && (CZ.Authoring.isValidURL(newContentItem.uri))) {
                     if (CZ.Authoring.contentItemMode === "createContentItem") {
-                        if (this.prevForm && this.prevForm instanceof CZ.UI.FormEditExhibit) {
+                        if (this.prevForm && this.prevForm instanceof UI.FormEditExhibit) {
                             this.isCancel = false;
                             this.prevForm.contentItemsListBox.add(newContentItem);
                             $.extend(this.exhibit.contentItems[this.contentItem.order], newContentItem);
@@ -162,7 +162,7 @@ var CZ;
                             this.back();
                         }
                     } else if (CZ.Authoring.contentItemMode === "editContentItem") {
-                        if (this.prevForm && this.prevForm instanceof CZ.UI.FormEditExhibit) {
+                        if (this.prevForm && this.prevForm instanceof UI.FormEditExhibit) {
                             this.isCancel = false;
                             var clickedListItem = this.prevForm.clickedListItem;
                             clickedListItem.iconImg.attr("src", newContentItem.uri);
@@ -220,8 +220,8 @@ var CZ;
             };
 
             FormEditCI.prototype.close = function (noAnimation) {
-                if (typeof noAnimation === "undefined") { noAnimation = false; }
                 var _this = this;
+                if (typeof noAnimation === "undefined") { noAnimation = false; }
                 if (this.isModified) {
                     if (window.confirm("There is unsaved data. Do you want to close without saving?")) {
                         this.isModified = false;

--- a/Source/Chronozoom.UI/ui/auth-edit-exhibit-form.js
+++ b/Source/Chronozoom.UI/ui/auth-edit-exhibit-form.js
@@ -315,8 +315,8 @@ var CZ;
             };
 
             FormEditExhibit.prototype.close = function (noAnimation) {
-                if (typeof noAnimation === "undefined") { noAnimation = false; }
                 var _this = this;
+                if (typeof noAnimation === "undefined") { noAnimation = false; }
                 if (this.isModified) {
                     if (window.confirm("There is unsaved data. Do you want to close without saving?")) {
                         this.isModified = false;
@@ -352,7 +352,7 @@ var CZ;
                 CZ.Common.vc.virtualCanvas("showNonRootVirtualSpace");
             };
             return FormEditExhibit;
-        })(CZ.UI.FormUpdateEntity);
+        })(UI.FormUpdateEntity);
         UI.FormEditExhibit = FormEditExhibit;
     })(CZ.UI || (CZ.UI = {}));
     var UI = CZ.UI;

--- a/Source/Chronozoom.UI/ui/contentitem-listbox.js
+++ b/Source/Chronozoom.UI/ui/contentitem-listbox.js
@@ -55,7 +55,7 @@ var CZ;
                 _super.prototype.remove.call(this, item);
             };
             return ContentItemListBox;
-        })(CZ.UI.ListBoxBase);
+        })(UI.ListBoxBase);
         UI.ContentItemListBox = ContentItemListBox;
 
         var ContentItemListItem = (function (_super) {
@@ -85,7 +85,7 @@ var CZ;
                 });
             }
             return ContentItemListItem;
-        })(CZ.UI.ListItemBase);
+        })(UI.ListItemBase);
         UI.ContentItemListItem = ContentItemListItem;
     })(CZ.UI || (CZ.UI = {}));
     var UI = CZ.UI;

--- a/Source/Chronozoom.UI/ui/tour-listbox.js
+++ b/Source/Chronozoom.UI/ui/tour-listbox.js
@@ -49,7 +49,7 @@ var CZ;
                 configurable: true
             });
             return TourListBox;
-        })(CZ.UI.ListBoxBase);
+        })(UI.ListBoxBase);
         UI.TourListBox = TourListBox;
 
         var TourListItem = (function (_super) {
@@ -94,7 +94,7 @@ var CZ;
                 }
             }
             return TourListItem;
-        })(CZ.UI.ListItemBase);
+        })(UI.ListItemBase);
         UI.TourListItem = TourListItem;
     })(CZ.UI || (CZ.UI = {}));
     var UI = CZ.UI;

--- a/Source/Chronozoom.UI/ui/tourstop-listbox.js
+++ b/Source/Chronozoom.UI/ui/tourstop-listbox.js
@@ -42,7 +42,7 @@ var CZ;
                 _super.call(this, container, listBoxInfo, listItemsInfo);
             }
             return TourStopListBox;
-        })(CZ.UI.ListBoxBase);
+        })(UI.ListBoxBase);
         UI.TourStopListBox = TourStopListBox;
 
         var TourStopListItem = (function (_super) {
@@ -107,7 +107,7 @@ var CZ;
                 myDescr.show(500);
             };
             return TourStopListItem;
-        })(CZ.UI.ListItemBase);
+        })(UI.ListItemBase);
         UI.TourStopListItem = TourStopListItem;
     })(CZ.UI || (CZ.UI = {}));
     var UI = CZ.UI;


### PR DESCRIPTION
This is a partial fix for Kiosk Mode. Change implemented to default to
unchecked. However, in this version, bug is still present where Kiosk
Mode and other theme values are not populated from the database when the
edit collection form is displayed. This bug is fully resolved in Neil's
MultiUser branch, which will hopefully be deployed within a day or so.
Please note only code changed was one line in
auth-edit-collection-form.ts. Other changes result from
compiling/building.
