### PR TITLE
JS and CSS Versioning

### DIFF
--- a/Source/Chronozoom.UI/cz.html
+++ b/Source/Chronozoom.UI/cz.html
@@ -33,7 +33,6 @@
             }
         })();
     </script>
-    <link rel="stylesheet" type="text/css" href="/css/cz.css" />
     <script type="text/javascript" src="//ajax.aspnetcdn.com/ajax/jQuery/jquery-1.7.2.min.js"></script>
     <script type="text/javascript" src="/scripts/external/airbrake-shim.js"></script>
     <script type="text/javascript" src="//code.jquery.com/ui/1.10.2/jquery-ui.js"></script>
@@ -48,12 +47,21 @@
     <script type="text/javascript" src="/scripts/external/seadragon-min.js"></script>
     <script type="text/javascript" src="/scripts/external/jquery.dotdotdot.js"></script>
     <script type="text/javascript">
+        function AddCSS(path)
+        {
+            var link    = document.createElement('link');
+            link.type   = 'text/css';
+            link.rel    = 'stylesheet';
+            link.href   = path + '?v=' + constants.cssFileVersion;
+            document.getElementsByTagName('head')[0].appendChild(link);
+        }
         function AddScript(path) {
-            var script = document.createElement("script");
+            var script  = document.createElement("script");
             script.type = "text/javascript";
-            script.src = path;
+            script.src  = path + '?v=' + constants.jsFileVersion;
             document.getElementsByTagName("head")[0].appendChild(script);
         }
+        AddCSS('/css/cz.min.css');
         if (Modernizr.canvas) {
             if (!constants.environment || constants.environment == 'Localhost') {
                 AddScript("/scripts/settings.js");

--- a/Source/Chronozoom.UI/cz.js
+++ b/Source/Chronozoom.UI/cz.js
@@ -3145,7 +3145,7 @@ var CZ;
                 _super.call(this, container, listBoxInfo, listItemsInfo);
             }
             return TourStopListBox;
-        })(CZ.UI.ListBoxBase);
+        })(UI.ListBoxBase);
         UI.TourStopListBox = TourStopListBox;
 
         var TourStopListItem = (function (_super) {
@@ -3210,7 +3210,7 @@ var CZ;
                 myDescr.show(500);
             };
             return TourStopListItem;
-        })(CZ.UI.ListItemBase);
+        })(UI.ListItemBase);
         UI.TourStopListItem = TourStopListItem;
     })(CZ.UI || (CZ.UI = {}));
     var UI = CZ.UI;
@@ -5564,7 +5564,7 @@ var CZ;
                 configurable: true
             });
             return TourListBox;
-        })(CZ.UI.ListBoxBase);
+        })(UI.ListBoxBase);
         UI.TourListBox = TourListBox;
 
         var TourListItem = (function (_super) {
@@ -5609,7 +5609,7 @@ var CZ;
                 }
             }
             return TourListItem;
-        })(CZ.UI.ListItemBase);
+        })(UI.ListItemBase);
         UI.TourListItem = TourListItem;
     })(CZ.UI || (CZ.UI = {}));
     var UI = CZ.UI;
@@ -10889,7 +10889,7 @@ var CZ;
                 CZ.Authoring.isActive = false;
                 CZ.Authoring.mode = "editTour";
 
-                CZ.Authoring.showEditTourForm(null);
+                Authoring.showEditTourForm(null);
             }
             UI.createTour = createTour;
 
@@ -13129,7 +13129,7 @@ var CZ;
                 _super.prototype.remove.call(this, item);
             };
             return ContentItemListBox;
-        })(CZ.UI.ListBoxBase);
+        })(UI.ListBoxBase);
         UI.ContentItemListBox = ContentItemListBox;
 
         var ContentItemListItem = (function (_super) {
@@ -13159,7 +13159,7 @@ var CZ;
                 });
             }
             return ContentItemListItem;
-        })(CZ.UI.ListItemBase);
+        })(UI.ListItemBase);
         UI.ContentItemListItem = ContentItemListItem;
     })(CZ.UI || (CZ.UI = {}));
     var UI = CZ.UI;
@@ -13497,8 +13497,8 @@ var CZ;
             };
 
             FormEditExhibit.prototype.close = function (noAnimation) {
-                if (typeof noAnimation === "undefined") { noAnimation = false; }
                 var _this = this;
+                if (typeof noAnimation === "undefined") { noAnimation = false; }
                 if (this.isModified) {
                     if (window.confirm("There is unsaved data. Do you want to close without saving?")) {
                         this.isModified = false;
@@ -13534,7 +13534,7 @@ var CZ;
                 CZ.Common.vc.virtualCanvas("showNonRootVirtualSpace");
             };
             return FormEditExhibit;
-        })(CZ.UI.FormUpdateEntity);
+        })(UI.FormUpdateEntity);
         UI.FormEditExhibit = FormEditExhibit;
     })(CZ.UI || (CZ.UI = {}));
     var UI = CZ.UI;
@@ -13650,7 +13650,7 @@ var CZ;
                     this.titleTextblock.text("Edit");
                     this.saveButton.text("Update Artifact");
 
-                    if (this.prevForm && this.prevForm instanceof CZ.UI.FormEditExhibit)
+                    if (this.prevForm && this.prevForm instanceof UI.FormEditExhibit)
                         this.closeButton.hide();
                     else
                         this.closeButton.show();
@@ -13687,7 +13687,7 @@ var CZ;
 
                 if ((CZ.Authoring.validateContentItems([newContentItem], this.mediaInput)) && (CZ.Authoring.isValidURL(newContentItem.uri))) {
                     if (CZ.Authoring.contentItemMode === "createContentItem") {
-                        if (this.prevForm && this.prevForm instanceof CZ.UI.FormEditExhibit) {
+                        if (this.prevForm && this.prevForm instanceof UI.FormEditExhibit) {
                             this.isCancel = false;
                             this.prevForm.contentItemsListBox.add(newContentItem);
                             $.extend(this.exhibit.contentItems[this.contentItem.order], newContentItem);
@@ -13697,7 +13697,7 @@ var CZ;
                             this.back();
                         }
                     } else if (CZ.Authoring.contentItemMode === "editContentItem") {
-                        if (this.prevForm && this.prevForm instanceof CZ.UI.FormEditExhibit) {
+                        if (this.prevForm && this.prevForm instanceof UI.FormEditExhibit) {
                             this.isCancel = false;
                             var clickedListItem = this.prevForm.clickedListItem;
                             clickedListItem.iconImg.attr("src", newContentItem.uri);
@@ -13755,8 +13755,8 @@ var CZ;
             };
 
             FormEditCI.prototype.close = function (noAnimation) {
-                if (typeof noAnimation === "undefined") { noAnimation = false; }
                 var _this = this;
+                if (typeof noAnimation === "undefined") { noAnimation = false; }
                 if (this.isModified) {
                     if (window.confirm("There is unsaved data. Do you want to close without saving?")) {
                         this.isModified = false;
@@ -14111,7 +14111,7 @@ var CZ;
                 });
             }
             return FormManageEditors;
-        })(CZ.UI.FormUpdateEntity);
+        })(UI.FormUpdateEntity);
         UI.FormManageEditors = FormManageEditors;
     })(CZ.UI || (CZ.UI = {}));
     var UI = CZ.UI;

--- a/Source/Chronozoom.UI/default.ashx.cs
+++ b/Source/Chronozoom.UI/default.ashx.cs
@@ -19,21 +19,13 @@ namespace Chronozoom.UI
 {
     public class PageInformation
     {
-        public PageInformation()
-        {
-            AnalyticsServiceId      = ConfigurationManager.AppSettings["AnalyticsServiceId"];
-            AirbrakeProjectId       = ConfigurationManager.AppSettings["AirbrakeProjectId"];
-            AirbrakeProjectKey      = ConfigurationManager.AppSettings["AirbrakeProjectKey"];
-            AirbrakeEnvironmentName = ConfigurationManager.AppSettings["AirbrakeEnvironmentName"];  if (AirbrakeEnvironmentName == "") AirbrakeEnvironmentName = "development";
-            OneDriveClientID        = ConfigurationManager.AppSettings["OneDriveClientID"];
-            Images = new List<string>();
-        }
-
         public string AnalyticsServiceId        { get; private set; }
         public string AirbrakeProjectId         { get; private set; }
         public string AirbrakeProjectKey        { get; private set; }
         public string AirbrakeEnvironmentName   { get; private set; }
         public string OneDriveClientID          { get; private set; }
+        public string CSSFileVersion            { get; private set; }
+        public string JSFileVersion             { get; private set; }
 
         [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
         public string Title { get; set; }
@@ -43,6 +35,37 @@ namespace Chronozoom.UI
 
         [SuppressMessage("Microsoft.Design", "CA1002:DoNotExposeGenericLists")]
         public List<string> Images { get; private set; }
+
+        // constructor
+        public PageInformation()
+        {
+            AnalyticsServiceId      = ConfigurationManager.AppSettings["AnalyticsServiceId"];
+            AirbrakeProjectId       = ConfigurationManager.AppSettings["AirbrakeProjectId"];
+            AirbrakeProjectKey      = ConfigurationManager.AppSettings["AirbrakeProjectKey"];
+            AirbrakeEnvironmentName = ConfigurationManager.AppSettings["AirbrakeEnvironmentName"];  if (AirbrakeEnvironmentName == "") AirbrakeEnvironmentName = "development";
+            OneDriveClientID        = ConfigurationManager.AppSettings["OneDriveClientID"];
+
+            CSSFileVersion  = GetFileVersion("/scripts/cz.js");
+            JSFileVersion   = GetFileVersion("/css/cz.min.css");
+
+            Images = new List<string>();
+        }
+
+        /// <summary>
+        /// Used to obtain a versioning value that can be used in a query string when linking static content such as .js and .css files.
+        /// The versioning value changes every time the file is changed, and can be used so that browsers do not need to be manually refreshed by users when static content changes.
+        /// For example, x.js?v=2014-12-31--17-30 is seen by browsers as a different file compared to x.js?v2015-01-01--00-00.
+        /// It should be noted that this particular approach is not be suitable for a web farm unless sticky IPs are used on the load balancer.
+        /// </summary>
+        /// <param name="relativePath">Path to static content file such as .js or .css file.</param>
+        /// <returns>String based off of file creation date and time.</returns>
+        private string GetFileVersion(string webPath)
+        {
+            FileInfo info   = new FileInfo(HttpContext.Current.Server.MapPath(webPath));
+            DateTime stamp  = info.LastWriteTimeUtc;
+
+            return stamp.ToString("yyyy-MM-dd--HH-mm-ss");
+        }
     }
 
     /// <summary>
@@ -221,6 +244,8 @@ namespace Chronozoom.UI
                 "airbrakeProjectKey: \""        + pageInformation.AirbrakeProjectKey        + "\", " +
                 "airbrakeEnvironmentName: \""   + pageInformation.AirbrakeEnvironmentName   + "\", " +
                 "onedriveClientId: \""          + pageInformation.OneDriveClientID          + "\", " +
+                "cssFileVersion: \""            + pageInformation.CSSFileVersion            + "\", " +
+                "jsFileVersion: \""             + pageInformation.JSFileVersion             + "\", " +
                 "environment: \""               + CurrentEnvironment.ToString()             + "\"  " +
                 "};";
 


### PR DESCRIPTION
Use a query string v= parameter with CZ-specific .js and .css files,
that changes automatically whenever these files are recompiled.
Effectively, users no longer need to manually refresh their browsers
whenever we update ChronoZoom CSS or JS files.
