### PR TITLE
Added one more link to the UW page.

### DIFF
--- a/Source/Chronozoom.UI/cz.html
+++ b/Source/Chronozoom.UI/cz.html
@@ -303,7 +303,7 @@
                     </a>
                 </li>
                 <li class="fleft">
-                    <a class="footer-link-credits elements-kiosk-disable" target="_blank" href="http://join.chronozoom.com/university-of-washington/">
+                    <a class="footer-link-credits elements-kiosk-disable" target="_blank" href="http://chronozoom.tumblr.com/university-of-washington/">
                         <img src="/images/credits/uw.png" border="0" />
                     </a>
                 </li>


### PR DESCRIPTION
I overlooked the link target for the UW footer logo. Apparently it pointed to a page on join.chronozoom.com, which is no longer in use and will eventually go away. I updated it to point to a new page on our tumblr blog.
