### PR TITLE
Changed Teacher Resources Link

### DIFF
--- a/Source/Chronozoom.UI/ui/start-page.html
+++ b/Source/Chronozoom.UI/ui/start-page.html
@@ -14,7 +14,7 @@
                 <div class="welcome-box-3">
                     Use ChronoZoom to get a perspective of the extensive scale of time and historical events relative to what happened around the world.
                     Become an author yourself! Simply log on with your social networking credentials to record your unique perspective or tell a story that needs to be told.
-                    <div class="welcome-link" onclick="CZ.StartPage.hide(); window.open('http://join.chronozoom.com/teach/', 'new')">New Teacher Resources</div>
+                    <div class="welcome-link" onclick="CZ.StartPage.hide(); window.open('http://chronozoom.tumblr.com/teach/', 'new')">New Teacher Resources</div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Per request from Lori, changed the new teacher resources link to
http://join.chronozoom.com/teach/ on the home page overlay.
